### PR TITLE
Google User Messaging Platform (UMP) support

### DIFF
--- a/samples/Foo.Bar.SampleApp.Net8/Foo.Bar.SampleApp.Net8.csproj
+++ b/samples/Foo.Bar.SampleApp.Net8/Foo.Bar.SampleApp.Net8.csproj
@@ -42,9 +42,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.14" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.14" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.100" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/Foo.Bar.SampleApp.Net8/MainPage.xaml
+++ b/samples/Foo.Bar.SampleApp.Net8/MainPage.xaml
@@ -11,65 +11,120 @@
         </Grid.RowDefinitions>
         <ScrollView>
             <VerticalStackLayout
-                Spacing="25"
-                Padding="0,25"
+                Spacing="16"
+                Padding="0,16"
                 VerticalOptions="Center">
 
-                <Label Padding="25, 0" Text="Rewarded:" />
-                <Button
-                    Text="Show rewarded (Prepare+Show)"
-                    SemanticProperties.Hint="Shows a test rewarded ad"
-                    Clicked="OnShowRewardedAdClicked"
-                    HorizontalOptions="Center"></Button>
-                <Button
-                    Text="Show rewarded (Create+Load+Show)"
-                    SemanticProperties.Hint="Shows a test rewarded ad"
-                    Clicked="OnCreateRewardedAdClicked"
-                    HorizontalOptions="Center"></Button>
-                
-                <Label Padding="25,0" Text="Rewarded Interstitial:" />
-                <Button
-                    Text="Show rewarded interstitial (Prepare+Show)"
-                    SemanticProperties.Hint="Shows a test rewarded interstitial ad"
-                    Clicked="OnShowRewardedInterstitialClicked"
-                    HorizontalOptions="Center" />
-                <Button
-                    Text="Show rewarded interstitial (Create+Load+Show)"
-                    SemanticProperties.Hint="Shows a test rewarded interstitial ad"
-                    Clicked="OnCreateRewardedInterstitialClicked"
-                    HorizontalOptions="Center" />
-                
-                <Label Padding="25,0" Text="Interstitial:" />
-                <Button
-                    Text="Show interstitial (Prepare+Show)"
-                    SemanticProperties.Hint="Shows a test interstitial ad"
-                    Clicked="OnShowInterstitialClicked"
-                    HorizontalOptions="Center" />
-                <Button
-                    Text="Show interstitial (Create+Load+Show)"
-                    SemanticProperties.Hint="Shows a test interstitial ad"
-                    Clicked="OnCreateInterstitialClicked"
-                    HorizontalOptions="Center" />
+                <HorizontalStackLayout Padding="16,0">
+                    <Label Text="Consent - Can request ads: " />
+                    <Label x:Name="CanRequestAdsLabel" Text="unknown" />
+                </HorizontalStackLayout>
 
-                <Label Padding="25,0" Text="SmartBanner:" />
+                <Grid Padding="16,0" ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <Button
+                        Text="Show if required"
+                        SemanticProperties.Hint="Shows the consent form only if required"
+                        Clicked="OnShowIfRequiredClicked"
+                        HorizontalOptions="Fill" />
+                    <Button
+                        Text="Privacy options"
+                        Grid.Column="1"
+                        SemanticProperties.Hint="Shows the privacy options form"
+                        Clicked="OnShowPrivacyOptionsClicked"
+                        HorizontalOptions="Fill" />
+                    <Button
+                        Text="Reset"
+                        Grid.Column="2"
+                        SemanticProperties.Hint="Resets the consent information"
+                        Clicked="OnResetClicked"
+                        HorizontalOptions="Fill" />
+                </Grid>
+
+                <Label Padding="16,0" Text="Rewarded:" />
+                <Grid Padding="16,0" ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <Button
+                        Text="Prepare + Show"
+                        SemanticProperties.Hint="Shows a test rewarded ad"
+                        Clicked="OnShowRewardedAdClicked"
+                        HorizontalOptions="Fill" />
+                    <Button
+                        Text="Create + Load + Show"
+                        Grid.Column="1"
+                        SemanticProperties.Hint="Shows a test rewarded ad"
+                        Clicked="OnCreateRewardedAdClicked"
+                        HorizontalOptions="Fill" />
+                </Grid>                
+                
+                <Label Padding="16,0" Text="Rewarded Interstitial:" />
+
+                <Grid Padding="16,0" ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Button
+                        Text="Prepare + Show"
+                        SemanticProperties.Hint="Shows a test rewarded interstitial ad"
+                        Clicked="OnShowRewardedInterstitialClicked"
+                        HorizontalOptions="Fill" />
+                    <Button
+                        Text="Create + Load + Show"
+                        Grid.Column="1"
+                        SemanticProperties.Hint="Shows a test rewarded interstitial ad"
+                        Clicked="OnCreateRewardedInterstitialClicked"
+                        HorizontalOptions="Fill" />
+                </Grid>
+
+
+                <Label Padding="16,0" Text="Interstitial:" />
+                <Grid Padding="16, 0" ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Button
+                        Text="Prepare + Show"
+                        SemanticProperties.Hint="Shows a test interstitial ad"
+                        Clicked="OnShowInterstitialClicked"
+                        HorizontalOptions="Fill" />
+                    <Button
+                        Text="Create + Load + Show"
+                        Grid.Column="1"
+                        SemanticProperties.Hint="Shows a test interstitial ad"
+                        Clicked="OnCreateInterstitialClicked"
+                        HorizontalOptions="Fill" />
+                </Grid>
+
+                <Label Padding="16,0" Text="SmartBanner:" />
                 <admob:BannerAd OnAdLoaded="BannerAd_OnAdLoaded" />
 
-                <Label Padding="25,0" Text="Banner:" />
+                <Label Padding="16,0" Text="Banner:" />
                 <admob:BannerAd AdSize="Banner" />
 
-                <Label Padding="25,0" Text="FullBanner:" />
+                <Label Padding="16,0" Text="FullBanner:" />
                 <admob:BannerAd AdSize="FullBanner" />
 
-                <Label Padding="25,0" Text="LargeBanner:" />
+                <Label Padding="16,0" Text="LargeBanner:" />
                 <admob:BannerAd AdSize="LargeBanner" />
 
-                <Label Padding="25,0" Text="Leaderboard:" />
+                <Label Padding="16,0" Text="Leaderboard:" />
                 <admob:BannerAd AdSize="Leaderboard" />
 
-                <Label Padding="25,0" Text="MediumRectangle:" />
+                <Label Padding="16,0" Text="MediumRectangle:" />
                 <admob:BannerAd AdSize="MediumRectangle" />
 
-                <Label Padding="25,0" Text="Custom (200x200):" />
+                <Label Padding="16,0" Text="Custom (200x200):" />
                 <admob:BannerAd AdSize="Custom" CustomAdWidth="200" CustomAdHeight="200" />
 
             </VerticalStackLayout>

--- a/samples/Foo.Bar.SampleApp.Net8/MainPage.xaml.cs
+++ b/samples/Foo.Bar.SampleApp.Net8/MainPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Plugin.AdMob;
 using Plugin.AdMob.Services;
 using System.Diagnostics;
+using ServiceProvider = Foo.Bar.SampleApp.Services.ServiceProvider;
 
 namespace Foo.Bar.SampleApp
 {
@@ -9,19 +10,23 @@ namespace Foo.Bar.SampleApp
         private readonly IInterstitialAdService _interstitialAdService;
         private readonly IRewardedInterstitialAdService _rewardedInterstitialAdService;
         private readonly IRewardedAdService _rewardedAdService;
+        private readonly IAdConsentService _adConsentService;
 
         public MainPage()
         {
             InitializeComponent();
 
-            _interstitialAdService = Services.ServiceProvider.GetService<IInterstitialAdService>();
+            _interstitialAdService = ServiceProvider.GetRequiredService<IInterstitialAdService>();
+            _rewardedAdService = ServiceProvider.GetRequiredService<IRewardedAdService>();
+            _rewardedInterstitialAdService = ServiceProvider.GetRequiredService<IRewardedInterstitialAdService>();
+            _adConsentService = ServiceProvider.GetRequiredService<IAdConsentService>();
+
             _interstitialAdService.PrepareAd();
-
-            _rewardedAdService = Services.ServiceProvider.GetService<IRewardedAdService>();
             _rewardedAdService.PrepareAd(onUserEarnedReward: UserDidEarnReward);
-
-            _rewardedInterstitialAdService = Services.ServiceProvider.GetService<IRewardedInterstitialAdService>();
             _rewardedInterstitialAdService.PrepareAd(onUserEarnedReward: UserDidEarnReward);
+
+            _adConsentService.OnConsentInfoUpdated += OnConsentInfoUpdated;
+            UpdateCanRequestAds();
         }
 
         private void OnShowInterstitialClicked(object sender, EventArgs e)
@@ -70,6 +75,31 @@ namespace Foo.Bar.SampleApp
             };
             rewardedInterstitialAd.OnAdLoaded += RewardedInterstitialAd_OnAdLoaded;
             rewardedInterstitialAd.Load();
+        }
+
+        private void OnShowIfRequiredClicked(object sender, EventArgs e)
+        {
+            _adConsentService.LoadAndShowConsentFormIfRequired();
+        }
+
+        private void OnShowPrivacyOptionsClicked(object sender, EventArgs e)
+        {
+            _adConsentService.ShowPrivacyOptionsForm();
+        }
+
+        private void OnResetClicked(object sender, EventArgs e)
+        {
+            _adConsentService.Reset();
+        }
+
+        private void UpdateCanRequestAds()
+        {
+            CanRequestAdsLabel.Text = _adConsentService.CanRequestAds().ToString();
+        }
+
+        private void OnConsentInfoUpdated(object? sender, IConsentInformation e)
+        {
+            UpdateCanRequestAds();
         }
 
         private void InterstitialAd_OnAdLoaded(object sender, EventArgs e)

--- a/samples/Foo.Bar.SampleApp.Net8/MauiProgram.cs
+++ b/samples/Foo.Bar.SampleApp.Net8/MauiProgram.cs
@@ -15,6 +15,12 @@ namespace Foo.Bar.SampleApp
             builder
                 .UseMauiApp<App>()
                 .UseAdMob()
+                .UseConsentDebugSettings(new ConsentDebugSettings
+                {
+                    Geography = ConsentDebugGeography.Eea,
+                    TestDeviceHashedIds = ["33BE2250B43518CCDA7DE426D04EE231"],
+                    Reset = true
+                })
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
@@ -22,7 +28,7 @@ namespace Foo.Bar.SampleApp
                 });
 
 #if DEBUG
-    		builder.Logging.AddDebug();
+            builder.Logging.AddDebug();
 #endif
 
             return builder.Build();

--- a/samples/Foo.Bar.SampleApp.Net8/Services/ServiceProvider.cs
+++ b/samples/Foo.Bar.SampleApp.Net8/Services/ServiceProvider.cs
@@ -2,18 +2,12 @@
 
 internal static class ServiceProvider
 {
-    public static TService GetService<TService>()
+    public static TService? GetService<TService>()
         => Current.GetService<TService>();
 
-    public static IServiceProvider Current
-        =>
-#if WINDOWS10_0_17763_0_OR_GREATER
-    MauiWinUIApplication.Current.Services;
-#elif ANDROID
-        MauiApplication.Current.Services;
-#elif IOS || MACCATALYST
-    MauiUIApplicationDelegate.Current.Services;
-#else
-    null;
-#endif
+    public static TService GetRequiredService<TService>() where TService : notnull
+        => Current.GetRequiredService<TService>();
+
+    public static IServiceProvider Current => 
+        (IPlatformApplication.Current ?? throw new InvalidOperationException("Cannot resolve current application.")).Services;
 }

--- a/samples/Foo.Bar.SampleApp.Net9/MainPage.xaml
+++ b/samples/Foo.Bar.SampleApp.Net9/MainPage.xaml
@@ -11,65 +11,120 @@
         </Grid.RowDefinitions>
         <ScrollView>
             <VerticalStackLayout
-                Spacing="25"
-                Padding="0,25"
+                Spacing="16"
+                Padding="0,16"
                 VerticalOptions="Center">
 
-                <Label Padding="25, 0" Text="Rewarded:" />
-                <Button
-                    Text="Show rewarded (Prepare+Show)"
-                    SemanticProperties.Hint="Shows a test rewarded ad"
-                    Clicked="OnShowRewardedAdClicked"
-                    HorizontalOptions="Center"></Button>
-                <Button
-                    Text="Show rewarded (Create+Load+Show)"
-                    SemanticProperties.Hint="Shows a test rewarded ad"
-                    Clicked="OnCreateRewardedAdClicked"
-                    HorizontalOptions="Center"></Button>
+                <HorizontalStackLayout Padding="16,0">
+                    <Label Text="Consent - Can request ads: " />
+                    <Label x:Name="CanRequestAdsLabel" Text="unknown" />
+                </HorizontalStackLayout>
 
-                <Label Padding="25,0" Text="Rewarded Interstitial:" />
-                <Button
-                    Text="Show rewarded interstitial (Prepare+Show)"
-                    SemanticProperties.Hint="Shows a test rewarded interstitial ad"
-                    Clicked="OnShowRewardedInterstitialClicked"
-                    HorizontalOptions="Center" />
-                <Button
-                    Text="Show rewarded interstitial (Create+Load+Show)"
-                    SemanticProperties.Hint="Shows a test rewarded interstitial ad"
-                    Clicked="OnCreateRewardedInterstitialClicked"
-                    HorizontalOptions="Center" />
+                <Grid Padding="16,0" ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="2*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
-                <Label Padding="25,0" Text="Interstitial:" />
-                <Button
-                    Text="Show interstitial (Prepare+Show)"
-                    SemanticProperties.Hint="Shows a test interstitial ad"
-                    Clicked="OnShowInterstitialClicked"
-                    HorizontalOptions="Center" />
-                <Button
-                    Text="Show interstitial (Create+Load+Show)"
-                    SemanticProperties.Hint="Shows a test interstitial ad"
-                    Clicked="OnCreateInterstitialClicked"
-                    HorizontalOptions="Center" />
+                    <Button
+                        Text="Show if required"
+                        SemanticProperties.Hint="Shows the consent form only if required"
+                        Clicked="OnShowIfRequiredClicked"
+                        HorizontalOptions="Fill" />
+                    <Button
+                        Text="Privacy options"
+                        Grid.Column="1"
+                        SemanticProperties.Hint="Shows the privacy options form"
+                        Clicked="OnShowPrivacyOptionsClicked"
+                        HorizontalOptions="Fill" />
+                    <Button
+                        Text="Reset"
+                        Grid.Column="2"
+                        SemanticProperties.Hint="Resets the consent information"
+                        Clicked="OnResetClicked"
+                        HorizontalOptions="Fill" />
+                </Grid>
 
-                <Label Padding="25,0" Text="SmartBanner:" />
+                <Label Padding="16,0" Text="Rewarded:" />
+                <Grid Padding="16,0" ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <Button
+                        Text="Prepare + Show"
+                        SemanticProperties.Hint="Shows a test rewarded ad"
+                        Clicked="OnShowRewardedAdClicked"
+                        HorizontalOptions="Fill" />
+                    <Button
+                        Text="Create + Load + Show"
+                        Grid.Column="1"
+                        SemanticProperties.Hint="Shows a test rewarded ad"
+                        Clicked="OnCreateRewardedAdClicked"
+                        HorizontalOptions="Fill" />
+                </Grid>
+
+                <Label Padding="16,0" Text="Rewarded Interstitial:" />
+
+                <Grid Padding="16,0" ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Button
+                        Text="Prepare + Show"
+                        SemanticProperties.Hint="Shows a test rewarded interstitial ad"
+                        Clicked="OnShowRewardedInterstitialClicked"
+                        HorizontalOptions="Fill" />
+                    <Button
+                        Text="Create + Load + Show"
+                        Grid.Column="1"
+                        SemanticProperties.Hint="Shows a test rewarded interstitial ad"
+                        Clicked="OnCreateRewardedInterstitialClicked"
+                        HorizontalOptions="Fill" />
+                </Grid>
+
+
+                <Label Padding="16,0" Text="Interstitial:" />
+                <Grid Padding="16, 0" ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Button
+                        Text="Prepare + Show"
+                        SemanticProperties.Hint="Shows a test interstitial ad"
+                        Clicked="OnShowInterstitialClicked"
+                        HorizontalOptions="Fill" />
+                    <Button
+                        Text="Create + Load + Show"
+                        Grid.Column="1"
+                        SemanticProperties.Hint="Shows a test interstitial ad"
+                        Clicked="OnCreateInterstitialClicked"
+                        HorizontalOptions="Fill" />
+                </Grid>
+
+                <Label Padding="16,0" Text="SmartBanner:" />
                 <admob:BannerAd OnAdLoaded="BannerAd_OnAdLoaded" />
 
-                <Label Padding="25,0" Text="Banner:" />
+                <Label Padding="16,0" Text="Banner:" />
                 <admob:BannerAd AdSize="Banner" />
 
-                <Label Padding="25,0" Text="FullBanner:" />
+                <Label Padding="16,0" Text="FullBanner:" />
                 <admob:BannerAd AdSize="FullBanner" />
 
-                <Label Padding="25,0" Text="LargeBanner:" />
+                <Label Padding="16,0" Text="LargeBanner:" />
                 <admob:BannerAd AdSize="LargeBanner" />
 
-                <Label Padding="25,0" Text="Leaderboard:" />
+                <Label Padding="16,0" Text="Leaderboard:" />
                 <admob:BannerAd AdSize="Leaderboard" />
 
-                <Label Padding="25,0" Text="MediumRectangle:" />
+                <Label Padding="16,0" Text="MediumRectangle:" />
                 <admob:BannerAd AdSize="MediumRectangle" />
 
-                <Label Padding="25,0" Text="Custom (200x200):" />
+                <Label Padding="16,0" Text="Custom (200x200):" />
                 <admob:BannerAd AdSize="Custom" CustomAdWidth="200" CustomAdHeight="200" />
 
             </VerticalStackLayout>

--- a/samples/Foo.Bar.SampleApp.Net9/MainPage.xaml.cs
+++ b/samples/Foo.Bar.SampleApp.Net9/MainPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Plugin.AdMob;
 using Plugin.AdMob.Services;
 using System.Diagnostics;
+using ServiceProvider = Foo.Bar.SampleApp.Services.ServiceProvider;
 
 namespace Foo.Bar.SampleApp
 {
@@ -9,19 +10,23 @@ namespace Foo.Bar.SampleApp
         private readonly IInterstitialAdService _interstitialAdService;
         private readonly IRewardedInterstitialAdService _rewardedInterstitialAdService;
         private readonly IRewardedAdService _rewardedAdService;
+        private readonly IAdConsentService _adConsentService;
 
         public MainPage()
         {
             InitializeComponent();
 
-            _interstitialAdService = Services.ServiceProvider.GetService<IInterstitialAdService>();
+            _interstitialAdService = ServiceProvider.GetRequiredService<IInterstitialAdService>();
+            _rewardedAdService = ServiceProvider.GetRequiredService<IRewardedAdService>();
+            _rewardedInterstitialAdService = ServiceProvider.GetRequiredService<IRewardedInterstitialAdService>();
+            _adConsentService = ServiceProvider.GetRequiredService<IAdConsentService>();
+
             _interstitialAdService.PrepareAd();
-
-            _rewardedAdService = Services.ServiceProvider.GetService<IRewardedAdService>();
             _rewardedAdService.PrepareAd(onUserEarnedReward: UserDidEarnReward);
-
-            _rewardedInterstitialAdService = Services.ServiceProvider.GetService<IRewardedInterstitialAdService>();
             _rewardedInterstitialAdService.PrepareAd(onUserEarnedReward: UserDidEarnReward);
+
+            _adConsentService.OnConsentInfoUpdated += OnConsentInfoUpdated;
+            UpdateCanRequestAds();
         }
 
         private void OnShowInterstitialClicked(object sender, EventArgs e)
@@ -70,6 +75,31 @@ namespace Foo.Bar.SampleApp
             };
             rewardedInterstitialAd.OnAdLoaded += RewardedInterstitialAd_OnAdLoaded;
             rewardedInterstitialAd.Load();
+        }
+
+        private void OnShowIfRequiredClicked(object sender, EventArgs e)
+        {
+            _adConsentService.LoadAndShowConsentFormIfRequired();
+        }
+
+        private void OnShowPrivacyOptionsClicked(object sender, EventArgs e)
+        {
+            _adConsentService.ShowPrivacyOptionsForm();
+        }
+
+        private void OnResetClicked(object sender, EventArgs e)
+        {
+            _adConsentService.Reset();
+        }
+
+        private void UpdateCanRequestAds()
+        {
+            CanRequestAdsLabel.Text = _adConsentService.CanRequestAds().ToString();
+        }
+
+        private void OnConsentInfoUpdated(object? sender, IConsentInformation e)
+        {
+            UpdateCanRequestAds();
         }
 
         private void InterstitialAd_OnAdLoaded(object sender, EventArgs e)

--- a/samples/Foo.Bar.SampleApp.Net9/MauiProgram.cs
+++ b/samples/Foo.Bar.SampleApp.Net9/MauiProgram.cs
@@ -15,6 +15,12 @@ namespace Foo.Bar.SampleApp
             builder
                 .UseMauiApp<App>()
                 .UseAdMob()
+                .UseConsentDebugSettings(new ConsentDebugSettings
+                {
+                    Geography = ConsentDebugGeography.Eea,
+                    TestDeviceHashedIds = ["33BE2250B43518CCDA7DE426D04EE231"],
+                    Reset = true
+                })
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
@@ -22,7 +28,7 @@ namespace Foo.Bar.SampleApp
                 });
 
 #if DEBUG
-    		builder.Logging.AddDebug();
+            builder.Logging.AddDebug();
 #endif
 
             return builder.Build();

--- a/samples/Foo.Bar.SampleApp.Net9/Services/ServiceProvider.cs
+++ b/samples/Foo.Bar.SampleApp.Net9/Services/ServiceProvider.cs
@@ -2,18 +2,12 @@
 
 internal static class ServiceProvider
 {
-    public static TService GetService<TService>()
+    public static TService? GetService<TService>()
         => Current.GetService<TService>();
 
-    public static IServiceProvider Current
-        =>
-#if WINDOWS10_0_17763_0_OR_GREATER
-    MauiWinUIApplication.Current.Services;
-#elif ANDROID
-        MauiApplication.Current.Services;
-#elif IOS || MACCATALYST
-    MauiUIApplicationDelegate.Current.Services;
-#else
-    null;
-#endif
+    public static TService GetRequiredService<TService>() where TService : notnull
+        => Current.GetRequiredService<TService>();
+
+    public static IServiceProvider Current =>
+        (IPlatformApplication.Current ?? throw new InvalidOperationException("Cannot resolve current application.")).Services;
 }

--- a/src/Plugin.AdMob/Config.cs
+++ b/src/Plugin.AdMob/Config.cs
@@ -1,4 +1,5 @@
-﻿using Plugin.AdMob.Configuration;
+﻿using Microsoft.Maui.LifecycleEvents;
+using Plugin.AdMob.Configuration;
 using Plugin.AdMob.Handlers;
 using Plugin.AdMob.Services;
 
@@ -21,9 +22,11 @@ public static class Config
     /// <param name="androidDefaultRewardedInterstitialAdUnitId">Optional interstitial rewarded ad unit ID to be used by default on Android. See <see cref="AdConfig.DefaultRewardedInterstitialAdUnitId" />.</param>
     /// <param name="iosDefaultRewardedAdUnitId">Optional rewarded ad unit ID to be used by default on iOS. See <see cref="AdConfig.DefaultRewardedAdUnitId" />.</param>
     /// <param name="iosDefaultRewardedInterstitialAdUnitId">Optional interstitial rewarded ad unit ID to be used by default on Android. See <see cref="AdConfig.DefaultRewardedInterstitialAdUnitId" />.</param>
+    /// <param name="disableConsentCheck">Default is false. When set to true, the plugin will no longer check if there is consent before making an ad request. You should use <see cref="IAdConsentService" /> to ask for consent and ensure you can request ads before making any ad request. If consent is missing, the Google Ads SDK will automatically drop the ad requests and no ads will be served.</param>
+    /// <param name="automaticallyAskForConsent">Default is true. When set to false, the plugin will no longer ask for consent automatically. Use <see cref="IAdConsentService" /> to manage consent.</param>
     /// <returns>The source MAUI application builder.</returns>
     public static MauiAppBuilder UseAdMob(
-        this MauiAppBuilder builder, 
+        this MauiAppBuilder builder,
         string androidDefaultBannerAdUnitId = null,
         string androidDefaultInterstitialAdUnitId = null,
         string iosDefaultBannerAdUnitId = null,
@@ -31,7 +34,9 @@ public static class Config
         string androidDefaultRewardedAdUnitId = null,
         string androidDefaultRewardedInterstitialAdUnitId = null,
         string iosDefaultRewardedAdUnitId = null,
-        string iosDefaultRewardedInterstitialAdUnitId = null)
+        string iosDefaultRewardedInterstitialAdUnitId = null,
+        bool disableConsentCheck = false,
+        bool automaticallyAskForConsent = true)
     {
 #if ANDROID
         AdConfig.DefaultBannerAdUnitId = androidDefaultBannerAdUnitId;
@@ -45,6 +50,8 @@ public static class Config
         AdConfig.DefaultRewardedInterstitialAdUnitId = iosDefaultRewardedInterstitialAdUnitId;
 #endif
 
+        AdConfig.DisableConsentCheck = disableConsentCheck;
+
         builder.ConfigureMauiHandlers(handlers =>
         {
             handlers.AddHandler(typeof(BannerAd), typeof(BannerAdHandler));
@@ -53,6 +60,37 @@ public static class Config
         builder.Services.AddSingleton<IInterstitialAdService, InterstitialAdService>();
         builder.Services.AddSingleton<IRewardedAdService, RewardedAdService>();
         builder.Services.AddSingleton<IRewardedInterstitialAdService, RewardedInterstitialAdService>();
+
+        var adConsentService = new AdConsentService();
+        builder.Services.AddSingleton<IAdConsentService>(adConsentService);
+
+        if (automaticallyAskForConsent is true)
+        {
+            builder.ConfigureLifecycleEvents(events =>
+            {
+#if ANDROID
+                events.AddAndroid(android => android.OnStart(_ => adConsentService.LoadAndShowConsentFormIfRequired()));
+#elif IOS
+                events.AddiOS(ios => ios.OnActivated(_ => adConsentService.LoadAndShowConsentFormIfRequired()));
+#endif
+            });
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the consent debug settings to be used during testing.
+    /// </summary>
+    /// <param name="builder">The MAUI application builder.</param>
+    /// <param name="consentDebugSettings">The consent debug settings.</param>
+    /// <returns>The source MAUI application builder.</returns>
+    public static MauiAppBuilder UseConsentDebugSettings(
+        this MauiAppBuilder builder,
+        ConsentDebugSettings consentDebugSettings
+        )
+    {
+        ConsentDebugSettings.Current = consentDebugSettings;
 
         return builder;
     }

--- a/src/Plugin.AdMob/Configuration/AdConfig.cs
+++ b/src/Plugin.AdMob/Configuration/AdConfig.cs
@@ -1,18 +1,39 @@
-﻿namespace Plugin.AdMob.Configuration;
+﻿using Plugin.AdMob.Services;
+
+namespace Plugin.AdMob.Configuration;
 
 public static class AdConfig
 {
+    /// <summary>
+    /// Optional banner ad unit ID to be used by default.
+    /// </summary>
     public static string DefaultBannerAdUnitId { get; set; }
 
+    /// <summary>
+    /// Optional interstitial ad unit ID to be used by default.
+    /// </summary>
     public static string DefaultInterstitialAdUnitId { get; set; }
-    
+
+    /// <summary>
+    /// Optional rewarded ad unit ID to be used by default
+    /// </summary>
     public static string DefaultRewardedAdUnitId { get; set; }
-    
+
+    /// <summary>
+    /// Optional rewarded interstitial ad unit ID to be used by default
+    /// </summary>
     public static string DefaultRewardedInterstitialAdUnitId { get; set; }
 
     public static IList<string> TestDevices { get; } = new List<string>();
 
     public static bool UseTestAdUnitIds { get; set; }
+
+    /// <summary>
+    /// When set to true, the plugin will no longer check if there is consent before making an ad request. 
+    /// You should <see cref="IAdConsentService" /> to ask for consent and ensure you can request ads before making any ad request. 
+    /// If consent is missing, the Google Ads SDK will automatically drop the ad requests and no ads will be served.
+    /// </summary>
+    public static bool DisableConsentCheck { get; set; }
 
     public static void AddTestDevice(string deviceId)
     {

--- a/src/Plugin.AdMob/Configuration/ConsentDebugSettings.cs
+++ b/src/Plugin.AdMob/Configuration/ConsentDebugSettings.cs
@@ -1,0 +1,59 @@
+﻿namespace Plugin.AdMob.Configuration;
+
+/// <summary>
+/// Debug settings to hardcode in consent requests during testing.
+/// </summary>
+public class ConsentDebugSettings
+{
+    internal static ConsentDebugSettings Current { get; set; }
+
+    /// <summary>
+    /// The debug geography used for testing purposes.
+    /// </summary>
+    public ConsentDebugGeography Geography { get; set; }
+
+    /// <summary>
+    /// The hashed device IDs that should be considered test device.
+    /// </summary>
+    public IList<string> TestDeviceHashedIds { get; set; } = [];
+
+    /// <summary>
+    /// When true, the consent information will be reset every time.
+    /// </summary>
+    public bool Reset { get; set; }
+
+    /// <summary>
+    /// Registers a device as a test device.
+    /// </summary>
+    /// <param name="hashedDeviceId">The hashed device ID that should be considered a test device.</param>
+    public void AddTestDeviceHashedId(string hashedDeviceId)
+    {
+        TestDeviceHashedIds.Add(hashedDeviceId);
+    }
+}
+
+/// <summary>
+/// Debug values for testing geography.
+/// </summary>
+public enum ConsentDebugGeography
+{
+    /// <summary>
+    /// Debug geography disabled for debug devices.
+    /// </summary>
+    Disabled = 0,
+
+    /// <summary>
+    /// Geography appears as in EEA for debug devices.
+    /// </summary>
+    Eea = 1,
+
+    /// <summary>
+    /// Geography appears as in a regulated US State for debug devices.
+    /// </summary>
+    RegulatedUsState = 3,
+
+    /// <summary>
+    /// Geography appears as in a region with no regulation in force for debug device.
+    /// </summary>
+    Other = 4,
+}

--- a/src/Plugin.AdMob/Platforms/Android/Consent/AdConsentService.cs
+++ b/src/Plugin.AdMob/Platforms/Android/Consent/AdConsentService.cs
@@ -1,0 +1,104 @@
+using Android.Gms.Ads;
+using System.Diagnostics;
+using Xamarin.Google.UserMesssagingPlatform;
+
+namespace Plugin.AdMob.Services;
+
+internal partial class AdConsentService :
+    AdLoadCallback,
+    IConsentFormOnConsentFormDismissedListener,
+    IConsentInformationOnConsentInfoUpdateFailureListener,
+    IConsentInformationOnConsentInfoUpdateSuccessListener
+{
+    Xamarin.Google.UserMesssagingPlatform.IConsentInformation _consentInformation;
+
+    public void LoadAndShowConsentFormIfRequired()
+    {
+        var activity = ActivityStateManager.Default.GetCurrentActivity();
+        _consentInformation = UserMessagingPlatform.GetConsentInformation(activity);
+
+        var requestParametersBuilder = new ConsentRequestParameters.Builder();
+
+        var ds = Configuration.ConsentDebugSettings.Current;
+        if (ds is not null)
+        {
+            if (ds.Reset)
+            {
+                Reset();
+            }
+
+            var debugSettingsBuilder = new ConsentDebugSettings.Builder(activity);
+            debugSettingsBuilder.SetDebugGeography((int)ds.Geography);
+
+            foreach (var testDeviceHashedId in Configuration.ConsentDebugSettings.Current.TestDeviceHashedIds)
+            {
+                debugSettingsBuilder.AddTestDeviceHashedId(testDeviceHashedId);
+            }
+
+            var debugSettings = debugSettingsBuilder.Build();
+
+            requestParametersBuilder.SetConsentDebugSettings(debugSettings);
+        }
+
+        var requestParameters = requestParametersBuilder.Build();
+        _consentInformation.RequestConsentInfoUpdate(activity, requestParameters, this, this);
+    }
+
+    public bool CanRequestAds()
+    {
+        return _consentInformation.CanRequestAds();
+    }
+
+    public bool IsPrivacyOptionsRequired()
+    {
+        return _consentInformation.PrivacyOptionsRequirementStatus == ConsentInformationPrivacyOptionsRequirementStatus.Required;
+    }
+
+    public void ShowPrivacyOptionsForm()
+    {
+        var activity = ActivityStateManager.Default.GetCurrentActivity();
+        UserMessagingPlatform.ShowPrivacyOptionsForm(activity, this);
+    }
+
+    public void Reset()
+    {
+        _consentInformation.Reset();
+        OnConsentInfoUpdated?.Invoke(this, GetConsentInformation());
+    }
+
+    public void OnConsentInfoUpdateSuccess()
+    {
+        Debug.Write($"[Plugin.AdMob] Consent info update was successful. Status: {_consentInformation.ConsentStatus}");
+
+        if (_consentInformation.ConsentStatus is ConsentInformationConsentStatus.Required)
+        {
+            var activity = ActivityStateManager.Default.GetCurrentActivity();
+            UserMessagingPlatform.LoadAndShowConsentFormIfRequired(activity, this);
+
+            return;
+        }
+
+        OnConsentInfoUpdated?.Invoke(this, GetConsentInformation());
+    }
+
+    public void OnConsentInfoUpdateFailure(FormError error)
+    {
+        Debug.Write($"[Plugin.AdMob] Consent info update failed: {error.Message}");
+        OnConsentInfoFailedToUpdate?.Invoke(this, new ConsentError(error.Message));
+    }
+
+    void IConsentFormOnConsentFormDismissedListener.OnConsentFormDismissed(FormError error)
+    {
+        if (error is not null)
+        {
+            Debug.Write($"[Plugin.AdMob] Consent form error: {error.Message}");
+            OnConsentFormError?.Invoke(this, new ConsentError(error.Message));
+            return;
+        }
+
+        OnConsentFormDismissed?.Invoke(this, EventArgs.Empty);
+        OnConsentInfoUpdated?.Invoke(this, GetConsentInformation());
+    }
+
+    private ConsentInformation GetConsentInformation() => new((ConsentStatus)_consentInformation.ConsentStatus, _consentInformation.CanRequestAds());
+}

--- a/src/Plugin.AdMob/Platforms/iOS/Banner/BannerAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/iOS/Banner/BannerAdHandler.cs
@@ -1,14 +1,17 @@
 ﻿using Google.MobileAds;
 using Microsoft.Maui.Handlers;
 using Plugin.AdMob.Configuration;
+using Plugin.AdMob.Services;
 using UIKit;
 
 namespace Plugin.AdMob.Handlers;
 
 internal partial class BannerAdHandler : ViewHandler<BannerAd, BannerView>
 {
-    public static IPropertyMapper<BannerAd, BannerAdHandler> PropertyMapper = new PropertyMapper<BannerAd, BannerAdHandler>(ViewMapper);
+    private IAdConsentService _adConsentService;
 
+    public static IPropertyMapper<BannerAd, BannerAdHandler> PropertyMapper 
+        = new PropertyMapper<BannerAd, BannerAdHandler>(ViewMapper);
     public BannerAdHandler() : base(PropertyMapper) { }
 
     protected override void DisconnectHandler(BannerView platformView)
@@ -19,9 +22,13 @@ internal partial class BannerAdHandler : ViewHandler<BannerAd, BannerView>
 
     protected override BannerView CreatePlatformView()
     {
+        _adConsentService = IPlatformApplication.Current.Services.GetService<IAdConsentService>();
+        _adConsentService.OnConsentInfoUpdated += (_, _) => LoadAd(PlatformView);
+
         var adSize = GetAdSize();
         var adView = new BannerView()
         {
+            AdSize = adSize,
             RootViewController = Platform.GetCurrentUIViewController()
         };
 
@@ -35,12 +42,7 @@ internal partial class BannerAdHandler : ViewHandler<BannerAd, BannerView>
             adView.AdUnitId = AdMobTestAdUnits.Banner;
         }
 
-        MobileAds.SharedInstance.RequestConfiguration.TestDeviceIdentifiers = AdConfig.TestDevices.ToArray();
-
-        var request = Request.GetDefaultRequest();
-
-        VirtualView.HeightRequest = adSize.Size.Height;
-        VirtualView.WidthRequest = adSize.Size.Width;
+        MobileAds.SharedInstance.RequestConfiguration.TestDeviceIdentifiers = [.. AdConfig.TestDevices];        
 
         adView.AdReceived += VirtualView.RaiseOnAdLoaded;
         adView.ReceiveAdFailed += (s, e) => VirtualView.RaiseOnAdFailedToLoad(this, new AdError(e.Error.DebugDescription));
@@ -49,9 +51,35 @@ internal partial class BannerAdHandler : ViewHandler<BannerAd, BannerView>
         adView.WillPresentScreen += VirtualView.RaiseOnAdOpened;
         adView.ScreenDismissed += VirtualView.RaiseOnAdClosed;
 
-        adView.LoadRequest(request);
+        if (CanRequestAds() is true)
+        {
+            LoadAd(adView);
+        }
+        else
+        {
+            VirtualView.HeightRequest = 0;
+            VirtualView.WidthRequest = 0;
+        }
 
         return adView;
+    }
+
+    private void LoadAd(BannerView adView)
+    {
+        if (CanRequestAds() is false)
+        {
+            VirtualView.HeightRequest = 0;
+            VirtualView.WidthRequest = 0;
+            return;
+        }
+
+        var request = Request.GetDefaultRequest();
+
+        adView.LoadRequest(request);
+
+        var adSize = GetAdSize();
+        VirtualView.WidthRequest = adSize.Size.Width;
+        VirtualView.HeightRequest = adSize.Size.Height;
     }
 
     private Google.MobileAds.AdSize GetAdSize()
@@ -72,4 +100,14 @@ internal partial class BannerAdHandler : ViewHandler<BannerAd, BannerView>
 
     private Google.MobileAds.AdSize GetSize(int width, int height)
         => new Google.MobileAds.AdSize { Size = new CoreGraphics.CGSize(width, height) };
+
+    private bool CanRequestAds()
+    {
+        if (AdConfig.DisableConsentCheck)
+        {
+            return true;
+        }
+
+        return _adConsentService.CanRequestAds();
+    }
 }

--- a/src/Plugin.AdMob/Platforms/iOS/Consent/AdConsentService.cs
+++ b/src/Plugin.AdMob/Platforms/iOS/Consent/AdConsentService.cs
@@ -1,0 +1,102 @@
+using Foundation;
+using Google.UserMessagingPlatform;
+using Plugin.AdMob.Configuration;
+using System.Diagnostics;
+
+namespace Plugin.AdMob.Services;
+
+internal partial class AdConsentService
+{
+    internal Google.UserMessagingPlatform.ConsentInformation ConsentInformation => Google.UserMessagingPlatform.ConsentInformation.SharedInstance;
+
+    internal Google.UserMessagingPlatform.ConsentStatus ConsentStatus => ConsentInformation?.ConsentStatus ?? Google.UserMessagingPlatform.ConsentStatus.Unknown;
+
+    public void LoadAndShowConsentFormIfRequired()
+    {
+        if (ConsentInformation is null)
+        {
+            return;
+        }
+
+        if (ConsentStatus is Google.UserMessagingPlatform.ConsentStatus.NotRequired ||
+            ConsentStatus is Google.UserMessagingPlatform.ConsentStatus.Obtained)
+        {
+            return;
+        }
+
+        RequestParameters requestParameters = new();
+
+        var ds = ConsentDebugSettings.Current;
+        if (ds is not null)
+        {
+            if (ds.Reset)
+            {
+                Reset();
+            }
+
+            requestParameters.DebugSettings = new()
+            {
+                TestDeviceIdentifiers = [.. ds.TestDeviceHashedIds],
+                Geography = (DebugGeography)ds.Geography
+            };
+        };
+
+        Google.UserMessagingPlatform.ConsentInformation.SharedInstance.RequestConsentInfoUpdateWithParameters(requestParameters, error =>
+        {
+            if (error is not null)
+            {
+                Debug.Write($"[Plugin.AdMob] Consent info update failed: {error.DebugDescription}");
+                OnConsentInfoFailedToUpdate?.Invoke(this, new ConsentError(error.DebugDescription));
+                return;
+            }
+
+            Debug.Write($"[Plugin.AdMob] Consent info update was successful. Status: {ConsentStatus}");
+
+            if (ConsentStatus is Google.UserMessagingPlatform.ConsentStatus.Required)
+            {
+                var viewController = Platform.GetCurrentUIViewController();
+                ConsentForm.LoadAndPresentIfRequiredFromViewController(viewController, OnConsentFormDismissedInternal);
+                return;
+            }
+
+            OnConsentInfoUpdated?.Invoke(this, GetConsentInformation());
+        });
+    }
+
+    public bool CanRequestAds()
+    {
+        return ConsentInformation?.CanRequestAds ?? false;
+    }
+
+    public bool IsPrivacyOptionsRequired()
+    {
+        return ConsentInformation.PrivacyOptionsRequirementStatus == UMPPrivacyOptionsRequirementStatus.Requried;
+    }
+
+    public void ShowPrivacyOptionsForm()
+    {
+        var viewController = Platform.GetCurrentUIViewController();
+        ConsentForm.PresentPrivacyOptionsFormFromViewController(viewController, OnConsentFormDismissedInternal);
+    }
+
+    public void Reset()
+    {
+        ConsentInformation.Reset();
+        OnConsentInfoUpdated?.Invoke(this, GetConsentInformation());
+    }
+
+    private void OnConsentFormDismissedInternal(NSError? error)
+    {
+        if (error is not null)
+        {
+            Debug.Write($"[Plugin.AdMob] Consent form error: {error.DebugDescription}");
+            OnConsentFormError?.Invoke(this, new ConsentError(error.DebugDescription));
+            return;
+        }
+
+        OnConsentFormDismissed?.Invoke(this, EventArgs.Empty);
+        OnConsentInfoUpdated?.Invoke(this, GetConsentInformation());
+    }
+
+    private ConsentInformation GetConsentInformation() => new((ConsentStatus)ConsentInformation.ConsentStatus, ConsentInformation.CanRequestAds);
+}

--- a/src/Plugin.AdMob/Plugin.AdMob.csproj
+++ b/src/Plugin.AdMob/Plugin.AdMob.csproj
@@ -7,14 +7,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<!--<Version>1.2.0</Version>-->
 		<Version>1.3.0-beta.$([System.DateTime]::UtcNow.ToString("yyMMddHHmm"))</Version>
-		<Description>.NET MAUI plugin for AdMob.</Description>
+		<Description>AdMob plugin for .NET MAUI.</Description>
 		<PackageProjectUrl>https://github.com/marius-bughiu/Plugin.AdMob</PackageProjectUrl>
 		<Authors>Marius Bughiu</Authors>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageIcon>icon.png</PackageIcon>
-
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+		<PackageTags>maui;admob;ump;dotnet;dotnet-maui;cross-platform;ios;android;google;ads;user-messaging-platform</PackageTags>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
@@ -33,24 +32,28 @@
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
 		<PackageReference Include="Xamarin.GooglePlayServices.Ads.Lite" Version="123.1.0.1" />
+		<PackageReference Include="Xamarin.Google.UserMessagingPlatform" Version="3.0.0.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-ios'">
 		<PackageReference Include="Jc.GMA.iOS" Version="9.14.0" />
+    	<PackageReference Include="Jc.UMP.iOS" Version="2.7.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.StartsWith('net8.0'))">
-		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.14" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.14" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.100" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
 		<PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.0.1" />
 		<PackageReference Include="Xamarin.GooglePlayServices.Ads.Lite" Version="122.3.0.3" />
+    	<PackageReference Include="Xamarin.Google.UserMessagingPlatform" Version="2.2.0.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
 		<PackageReference Include="Jc.GMA.iOS" Version="9.14.0" />
+    	<PackageReference Include="Jc.UMP.iOS" Version="2.7.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Plugin.AdMob/Services/Consent/AdConsentService.cs
+++ b/src/Plugin.AdMob/Services/Consent/AdConsentService.cs
@@ -1,0 +1,62 @@
+using Plugin.AdMob.Configuration;
+
+namespace Plugin.AdMob.Services;
+
+/// <summary>
+/// Provides an API to manage user consent through Google's User Messaging Platform (UMP).
+/// </summary>
+public interface IAdConsentService
+{
+    /// <summary>
+    /// Raised when the consent information has been updated. This does not guarantee that consent has been obtained.
+    /// </summary>
+    event EventHandler<IConsentInformation> OnConsentInfoUpdated;
+
+    /// <summary>
+    /// Raised when we failed to update the consent information.
+    /// </summary>
+    event EventHandler<IConsentError> OnConsentInfoFailedToUpdate;
+
+    /// <summary>
+    /// Raised after the user has dismissed the consent form.
+    /// </summary>
+    event EventHandler OnConsentFormDismissed;
+
+    /// <summary>
+    /// Raised when we fail to show the consent form.
+    /// </summary>
+    event EventHandler<IConsentError> OnConsentFormError;
+
+    /// <summary>
+    /// Updates the consent information and shows the consent form if required.
+    /// </summary>
+    void LoadAndShowConsentFormIfRequired() => throw new NotImplementedException();
+
+    /// <summary>
+    /// Returns true when all the criteria for requesting ads is met. Doesn't take into account <see cref="AdConfig.DisableConsentCheck" />.
+    /// </summary>
+    bool CanRequestAds() => throw new NotImplementedException();
+
+    /// <summary>
+    /// Determines if the privacy options form is required.
+    /// </summary>
+    bool IsPrivacyOptionsRequired() => throw new NotImplementedException();
+
+    /// <summary>
+    /// Presents the user with the privacy options form.
+    /// </summary>
+    void ShowPrivacyOptionsForm() => throw new NotImplementedException();
+
+    /// <summary>
+    /// Resets the stored consent information. Should only be used during testing.
+    /// </summary>
+    void Reset() => throw new NotImplementedException();
+}
+
+internal partial class AdConsentService : IAdConsentService
+{
+    public event EventHandler<IConsentInformation> OnConsentInfoUpdated;
+    public event EventHandler<IConsentError> OnConsentInfoFailedToUpdate;
+    public event EventHandler OnConsentFormDismissed;
+    public event EventHandler<IConsentError> OnConsentFormError;
+}

--- a/src/Plugin.AdMob/Services/Consent/ConsentError.cs
+++ b/src/Plugin.AdMob/Services/Consent/ConsentError.cs
@@ -1,12 +1,12 @@
 ﻿namespace Plugin.AdMob;
 
-public interface IAdError
+public interface IConsentError
 {
     string Message { get; }
 }
 
-internal class AdError(string message) 
-    : IAdError
+internal class ConsentError(string message) 
+    : IConsentError
 {
     public string Message { get; } = message;
 }

--- a/src/Plugin.AdMob/Services/Consent/ConsentInformation.cs
+++ b/src/Plugin.AdMob/Services/Consent/ConsentInformation.cs
@@ -1,0 +1,51 @@
+﻿namespace Plugin.AdMob;
+
+/// <summary>
+/// Consent status values.
+/// </summary>
+public enum ConsentStatus
+{
+    /// <summary>
+    /// Consent status is unknown.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// User consent not required.
+    /// </summary>
+    NotRequired = 1,
+
+    /// <summary>
+    /// User consent required but not yet obtained.
+    /// </summary>
+    Required = 2,
+
+    /// <summary>
+    /// User consent obtained.
+    /// </summary>
+    Obtained = 3
+}
+
+/// <summary>
+/// A snapshot in time of the user's consent information.
+/// </summary>
+public interface IConsentInformation
+{
+    /// <summary>
+    /// The user's consent status.
+    /// </summary>
+    public ConsentStatus Status { get; }
+
+    /// <summary>
+    /// Determines whether all the criteria for requesting ads is met.
+    /// </summary>
+    public bool CanRequestAds { get; }
+}
+
+internal class ConsentInformation(ConsentStatus status, bool canRequestAds) 
+    : IConsentInformation
+{
+    public ConsentStatus Status { get; } = status;
+
+    public bool CanRequestAds { get; } = canRequestAds;
+}

--- a/src/Plugin.AdMob/Services/InterstitialAdService.cs
+++ b/src/Plugin.AdMob/Services/InterstitialAdService.cs
@@ -11,7 +11,8 @@ public interface IInterstitialAdService
     void ShowAd();
 }
 
-internal class InterstitialAdService : IInterstitialAdService
+internal class InterstitialAdService(IAdConsentService _adConsentService) 
+    : IInterstitialAdService
 {
     private IInterstitialAd _interstitialAd;
 
@@ -24,6 +25,11 @@ internal class InterstitialAdService : IInterstitialAdService
 
     public void PrepareAd(string adUnitId = null)
     {
+        if (CanRequestAds() is false)
+        {
+            return;
+        }
+
         var interstitialAd = CreateAd(adUnitId);
         interstitialAd.Load();
 
@@ -43,5 +49,15 @@ internal class InterstitialAdService : IInterstitialAdService
         }
 
         return adUnitId ?? AdConfig.DefaultInterstitialAdUnitId;
+    }
+
+    private bool CanRequestAds()
+    {
+        if (AdConfig.DisableConsentCheck)
+        {
+            return true;
+        }
+
+        return _adConsentService.CanRequestAds();
     }
 }

--- a/src/Plugin.AdMob/Services/RewardedAdService.cs
+++ b/src/Plugin.AdMob/Services/RewardedAdService.cs
@@ -11,7 +11,8 @@ public interface IRewardedAdService
     void ShowAd();
 }
 
-internal class RewardedAdService : IRewardedAdService
+internal class RewardedAdService(IAdConsentService _adConsentService) 
+    : IRewardedAdService
 {
     private IRewardedAd _rewardedAd;
     
@@ -24,6 +25,11 @@ internal class RewardedAdService : IRewardedAdService
 
     public void PrepareAd(string adUnitId = null, Action<RewardItem> onUserEarnedReward = null)
     {
+        if (CanRequestAds() is false)
+        {
+            return;
+        }
+
         var rewardedAd = CreateAd(adUnitId);
         
         if (onUserEarnedReward != null)
@@ -48,5 +54,15 @@ internal class RewardedAdService : IRewardedAdService
         }
 
         return adUnitId ?? AdConfig.DefaultRewardedAdUnitId;
+    }
+
+    private bool CanRequestAds()
+    {
+        if (AdConfig.DisableConsentCheck)
+        {
+            return true;
+        }
+
+        return _adConsentService.CanRequestAds();
     }
 }

--- a/src/Plugin.AdMob/Services/RewardedInterstitialAdService.cs
+++ b/src/Plugin.AdMob/Services/RewardedInterstitialAdService.cs
@@ -11,7 +11,8 @@ public interface IRewardedInterstitialAdService
     void ShowAd();
 }
 
-internal class RewardedInterstitialAdService : IRewardedInterstitialAdService
+internal class RewardedInterstitialAdService(IAdConsentService _adConsentService) 
+    : IRewardedInterstitialAdService
 {
     private IRewardedInterstitialAd _rewardedInterstitialAd;
     
@@ -24,6 +25,11 @@ internal class RewardedInterstitialAdService : IRewardedInterstitialAdService
     
     public void PrepareAd(string adUnitId = null, Action<RewardItem> onUserEarnedReward = null)
     {
+        if (CanRequestAds() is false)
+        {
+            return;
+        }
+
         var rewardedInterstitialAd = CreateAd(adUnitId);
         
         if (onUserEarnedReward != null)
@@ -48,5 +54,15 @@ internal class RewardedInterstitialAdService : IRewardedInterstitialAdService
         }
 
         return adUnitId ?? AdConfig.DefaultRewardedInterstitialAdUnitId;
+    }
+
+    private bool CanRequestAds()
+    {
+        if (AdConfig.DisableConsentCheck)
+        {
+            return true;
+        }
+
+        return _adConsentService.CanRequestAds();
     }
 }


### PR DESCRIPTION
Enhancement: #5

References:
- docs: https://developers.google.com/admob/android/privacy
- integration video (Android): https://www.youtube.com/watch?v=SysASyh9XKo
- reference implementation: [iOS](https://github.com/jcsawyer/Jc.AdMob.Avalonia/blob/main/src/Jc.AdMob.Avalonia.iOS/AdConsentiOS.cs), [android](https://github.com/jcsawyer/Jc.AdMob.Avalonia/blob/main/src/Jc.AdMob.Avalonia.Android/AdConsentAndroid.cs)

AdMob will automatically pick up the consent information and use it in the ad request. ([ref1](https://groups.google.com/g/google-admob-ads-sdk/c/I6j0Pr-_ziY/m/Qf3pNezGBAAJ), [ref2](https://support.google.com/admob/answer/9760862))

> GPT, GPT Passbacks, AdSense, and Ad Exchange Tags will automatically communicate with the IAB CMP to forward the TC string to AdMob without publisher configuration. IMA SDK and Mobile Ads SDK will automatically obtain, parse, and respect the TC string from within local storage.

> The IAB TC string is automatically passed to Google’s programmatic channels without configuration required by publishers.

TODO:
- support for `setTagForUnderAgeOfConsent` (separate PR)