### PR TITLE
Update iOS bindings libraries

### DIFF
--- a/samples/Foo.Bar.SampleApp.Hybrid/Foo.Bar.SampleApp.Hybrid.csproj
+++ b/samples/Foo.Bar.SampleApp.Hybrid/Foo.Bar.SampleApp.Hybrid.csproj
@@ -53,4 +53,19 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Plugin.AdMob\Plugin.AdMob.csproj" />
 	</ItemGroup>
+	
+	<Target Name="LinkWithSwift" DependsOnTargets="_ParseBundlerArguments;_DetectSdkLocations" BeforeTargets="_LinkNativeExecutable">
+		<PropertyGroup>
+			<_SwiftPlatform Condition="$(RuntimeIdentifier.StartsWith('iossimulator-'))">iphonesimulator</_SwiftPlatform>
+			<_SwiftPlatform Condition="$(RuntimeIdentifier.StartsWith('ios-'))">iphoneos</_SwiftPlatform>
+		</PropertyGroup>
+		<ItemGroup>
+			<_CustomLinkFlags Include="-L" />
+			<_CustomLinkFlags Include="/usr/lib/swift" />
+			<_CustomLinkFlags Include="-L" />
+			<_CustomLinkFlags Include="$(_SdkDevPath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(_SwiftPlatform)" />
+			<_CustomLinkFlags Include="-Wl,-rpath" />
+			<_CustomLinkFlags Include="-Wl,/usr/lib/swift" />
+		</ItemGroup>
+	</Target>
 </Project>

--- a/samples/Foo.Bar.SampleApp.Hybrid/Platforms/iOS/Info.plist
+++ b/samples/Foo.Bar.SampleApp.Hybrid/Platforms/iOS/Info.plist
@@ -30,8 +30,6 @@
     <string>Assets.xcassets/appicon.appiconset</string>
 	<key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-3940256099942544~1458002511</string>
-	<key>GADIsAdManagerApp</key>
-	<true/>
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>

--- a/samples/Foo.Bar.SampleApp.Net8/Foo.Bar.SampleApp.Net8.csproj
+++ b/samples/Foo.Bar.SampleApp.Net8/Foo.Bar.SampleApp.Net8.csproj
@@ -50,4 +50,19 @@
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\Plugin.AdMob\Plugin.AdMob.csproj" />
 	</ItemGroup>
+	
+	<Target Name="LinkWithSwift" DependsOnTargets="_ParseBundlerArguments;_DetectSdkLocations" BeforeTargets="_LinkNativeExecutable">
+		<PropertyGroup>
+			<_SwiftPlatform Condition="$(RuntimeIdentifier.StartsWith('iossimulator-'))">iphonesimulator</_SwiftPlatform>
+			<_SwiftPlatform Condition="$(RuntimeIdentifier.StartsWith('ios-'))">iphoneos</_SwiftPlatform>
+		</PropertyGroup>
+		<ItemGroup>
+			<_CustomLinkFlags Include="-L" />
+			<_CustomLinkFlags Include="/usr/lib/swift" />
+			<_CustomLinkFlags Include="-L" />
+			<_CustomLinkFlags Include="$(_SdkDevPath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(_SwiftPlatform)" />
+			<_CustomLinkFlags Include="-Wl,-rpath" />
+			<_CustomLinkFlags Include="-Wl,/usr/lib/swift" />
+		</ItemGroup>
+	</Target>
 </Project>

--- a/samples/Foo.Bar.SampleApp.Net8/Platforms/iOS/Info.plist
+++ b/samples/Foo.Bar.SampleApp.Net8/Platforms/iOS/Info.plist
@@ -30,8 +30,6 @@
 	<string>Assets.xcassets/appicon.appiconset</string>
 	<key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-3940256099942544~1458002511</string>
-	<key>GADIsAdManagerApp</key>
-	<true/>
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>

--- a/samples/Foo.Bar.SampleApp.Net9/Foo.Bar.SampleApp.Net9.csproj
+++ b/samples/Foo.Bar.SampleApp.Net9/Foo.Bar.SampleApp.Net9.csproj
@@ -50,4 +50,19 @@
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\Plugin.AdMob\Plugin.AdMob.csproj" />
 	</ItemGroup>
+
+	<Target Name="LinkWithSwift" DependsOnTargets="_ParseBundlerArguments;_DetectSdkLocations" BeforeTargets="_LinkNativeExecutable">
+		<PropertyGroup>
+			<_SwiftPlatform Condition="$(RuntimeIdentifier.StartsWith('iossimulator-'))">iphonesimulator</_SwiftPlatform>
+			<_SwiftPlatform Condition="$(RuntimeIdentifier.StartsWith('ios-'))">iphoneos</_SwiftPlatform>
+		</PropertyGroup>
+		<ItemGroup>
+			<_CustomLinkFlags Include="-L" />
+			<_CustomLinkFlags Include="/usr/lib/swift" />
+			<_CustomLinkFlags Include="-L" />
+			<_CustomLinkFlags Include="$(_SdkDevPath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(_SwiftPlatform)" />
+			<_CustomLinkFlags Include="-Wl,-rpath" />
+			<_CustomLinkFlags Include="-Wl,/usr/lib/swift" />
+		</ItemGroup>
+	</Target>
 </Project>

--- a/samples/Foo.Bar.SampleApp.Net9/Platforms/iOS/Info.plist
+++ b/samples/Foo.Bar.SampleApp.Net9/Platforms/iOS/Info.plist
@@ -30,8 +30,6 @@
 	<string>Assets.xcassets/appicon.appiconset</string>
 	<key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-3940256099942544~1458002511</string>
-	<key>GADIsAdManagerApp</key>
-	<true/>
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>

--- a/src/Plugin.AdMob/Plugin.AdMob.csproj
+++ b/src/Plugin.AdMob/Plugin.AdMob.csproj
@@ -22,14 +22,14 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-	    <SupportedOSPlatformVersion>11.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-ios'">12.2</SupportedOSPlatformVersion>
-    </PropertyGroup>
-	
+		<SupportedOSPlatformVersion>12.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-ios'">12.2</SupportedOSPlatformVersion>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="MinVer" Version="6.0.0">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Xamarin.Build.Download" Version="0.11.4" />
 	</ItemGroup>
@@ -45,8 +45,8 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-ios'">
-		<PackageReference Include="Jc.GMA.iOS" Version="9.14.0" />
-    	<PackageReference Include="Jc.UMP.iOS" Version="2.7.1" />
+		<PackageReference Include="Jc.GMA.iOS" Version="11.13.2" />
+		<PackageReference Include="Jc.UMP.iOS" Version="2.7.3" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.StartsWith('net8.0'))">
@@ -57,12 +57,12 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-android'">
 		<PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.0.1" />
 		<PackageReference Include="Xamarin.GooglePlayServices.Ads.Lite" Version="122.3.0.3" />
-    	<PackageReference Include="Xamarin.Google.UserMessagingPlatform" Version="2.2.0.1" />
+		<PackageReference Include="Xamarin.Google.UserMessagingPlatform" Version="2.2.0.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-ios'">
-		<PackageReference Include="Jc.GMA.iOS" Version="9.14.0" />
-    	<PackageReference Include="Jc.UMP.iOS" Version="2.7.1" />
+		<PackageReference Include="Jc.GMA.iOS" Version="11.13.2" />
+		<PackageReference Include="Jc.UMP.iOS" Version="2.7.3" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Updates iOS bindings library `Jc.GMA.iOS` to `11.13.2`
- Minimum supported iOS version for receiving ads is iOS 13

iOS SDK breaking changes:
```
Breaking changes:
- The SDK no longer depends directly on GoogleAppMeasurement. To continue collecting user metrics in AdMob, link your
- AdMob app to Firebase and integrate the Google Analytics for Firebase SDK into your app.
- Updated the minimum supported Xcode version to 15.1.
- Updated the minimum deployment target to iOS 12.
- Updated the minimum OS required to receive ads to iOS 13.
- Many previously deprecated APIs have been removed.
```

Addresses: https://github.com/marius-bughiu/Plugin.AdMob/issues/25 and https://github.com/marius-bughiu/Plugin.AdMob/discussions/24