### PR TITLE
Stub implementations for maccatalyst and windows

### DIFF
--- a/src/Plugin.AdMob/Config.cs
+++ b/src/Plugin.AdMob/Config.cs
@@ -78,9 +78,10 @@ public static class Config
         builder.Services.AddSingleton<IAppOpenAdService, AppOpenAdService>();
         builder.Services.AddSingleton<INativeAdService, NativeAdService>();
 
-        var adConsentService = new AdConsentService();
+        IAdConsentService adConsentService = new AdConsentService();
         builder.Services.AddSingleton<IAdConsentService>(adConsentService);
 
+#if ANDROID || IOS
         if (automaticallyAskForConsent is true)
         {
             builder.ConfigureLifecycleEvents(events =>
@@ -93,8 +94,6 @@ public static class Config
             });
         }
 
-        return builder;
-
         void OnStart()
         {
             if (_initialized)
@@ -105,6 +104,9 @@ public static class Config
             _initialized = true;
             adConsentService.LoadAndShowConsentFormIfRequired();
         }
+#endif
+
+        return builder;
     }
 
     /// <summary>

--- a/src/Plugin.AdMob/Platforms/MacCatalyst/Banner/BannerAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/MacCatalyst/Banner/BannerAdHandler.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Maui.Handlers;
+using UIKit;
+
+namespace Plugin.AdMob.Handlers;
+
+internal partial class BannerAdHandler : ViewHandler<BannerAd, UIView>
+{
+    public static IPropertyMapper<BannerAd, BannerAdHandler> PropertyMapper
+        = new PropertyMapper<BannerAd, BannerAdHandler>(ViewMapper);
+    public BannerAdHandler() : base(PropertyMapper) { }
+
+    protected override UIView CreatePlatformView()
+    {
+        return new UIView();
+    }
+}

--- a/src/Plugin.AdMob/Platforms/MacCatalyst/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/MacCatalyst/Native/NativeAdHandler.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Maui.Handlers;
+using UIKit;
+
+namespace Plugin.AdMob.Handlers;
+
+internal partial class NativeAdHandler : ViewHandler<NativeAdView, UIView>
+{
+    public static IPropertyMapper<NativeAdView, NativeAdHandler> PropertyMapper
+        = new PropertyMapper<NativeAdView, NativeAdHandler>(ViewMapper);
+    public NativeAdHandler() : base(PropertyMapper) { }
+
+    protected override UIView CreatePlatformView()
+    {
+        return new UIView();
+    }
+}

--- a/src/Plugin.AdMob/Platforms/Windows/Banner/BannerAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/Windows/Banner/BannerAdHandler.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Maui.Handlers;
+
+namespace Plugin.AdMob.Handlers;
+
+internal partial class BannerAdHandler : ViewHandler<BannerAd, Microsoft.UI.Xaml.Controls.Border>
+{
+    public static IPropertyMapper<BannerAd, BannerAdHandler> PropertyMapper
+        = new PropertyMapper<BannerAd, BannerAdHandler>(ViewMapper);
+    public BannerAdHandler() : base(PropertyMapper) { }
+
+    protected override Microsoft.UI.Xaml.Controls.Border CreatePlatformView()
+    {
+        return new Microsoft.UI.Xaml.Controls.Border() { BorderThickness = new Microsoft.UI.Xaml.Thickness(0) };
+    }
+}

--- a/src/Plugin.AdMob/Platforms/Windows/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/Windows/Native/NativeAdHandler.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Maui.Handlers;
+
+namespace Plugin.AdMob.Handlers;
+
+internal partial class NativeAdHandler : ViewHandler<NativeAdView, Microsoft.UI.Xaml.Controls.Border>
+{
+    public static IPropertyMapper<NativeAdView, NativeAdHandler> PropertyMapper
+        = new PropertyMapper<NativeAdView, NativeAdHandler>(ViewMapper);
+    public NativeAdHandler() : base(PropertyMapper) { }
+
+    protected override Microsoft.UI.Xaml.Controls.Border CreatePlatformView()
+    {
+        return new Microsoft.UI.Xaml.Controls.Border() { BorderThickness = new Microsoft.UI.Xaml.Thickness(0) };
+    }
+}

--- a/src/Plugin.AdMob/Plugin.AdMob.csproj
+++ b/src/Plugin.AdMob/Plugin.AdMob.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net9.0-android;net9.0-ios</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst;net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0</TargetFrameworks>
+		
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -14,6 +16,9 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageTags>maui;admob;ump;dotnet;dotnet-maui;cross-platform;ios;android;google;ads;user-messaging-platform</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+
+		<MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>
+		<PackageVersion>1.0.0-dev.$([System.DateTime]::UtcNow.ToString("yyMMddHHmm"))</PackageVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -24,6 +29,13 @@
 	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
 		<SupportedOSPlatformVersion>12.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-ios'">12.2</SupportedOSPlatformVersion>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Plugin.AdMob/Services/AppOpenAdService.cs
+++ b/src/Plugin.AdMob/Services/AppOpenAdService.cs
@@ -89,10 +89,12 @@ internal class AppOpenAdService(IAdConsentService _adConsentService)
 
     private static string? GetAdUnitId(string? adUnitId)
     {
+#if ANDROID || IOS
         if (AdConfig.UseTestAdUnitIds)
         {
             return AdMobTestAdUnits.OpenApp;
         }
+#endif
 
         return adUnitId ?? AdConfig.DefaultAppOpenAdUnitId;
     }

--- a/src/Plugin.AdMob/Services/InterstitialAdService.cs
+++ b/src/Plugin.AdMob/Services/InterstitialAdService.cs
@@ -89,10 +89,12 @@ internal class InterstitialAdService(IAdConsentService _adConsentService)
 
     private static string? GetAdUnitId(string? adUnitId)
     {
+#if ANDROID || IOS
         if (AdConfig.UseTestAdUnitIds)
         {
             return AdMobTestAdUnits.Interstitial;
         }
+#endif
 
         return adUnitId ?? AdConfig.DefaultInterstitialAdUnitId;
     }

--- a/src/Plugin.AdMob/Services/NativeAdService.cs
+++ b/src/Plugin.AdMob/Services/NativeAdService.cs
@@ -32,10 +32,12 @@ internal class NativeAdService(IAdConsentService _adConsentService)
 
     private static string? GetAdUnitId(string? adUnitId)
     {
+#if ANDROID || IOS
         if (AdConfig.UseTestAdUnitIds)
         {
             return AdMobTestAdUnits.Native;
         }
+#endif
 
         return adUnitId ?? AdConfig.DefaultNativeAdUnitId;
     }

--- a/src/Plugin.AdMob/Services/RewardedAdService.cs
+++ b/src/Plugin.AdMob/Services/RewardedAdService.cs
@@ -94,10 +94,12 @@ internal class RewardedAdService(IAdConsentService _adConsentService)
     
     private static string? GetAdUnitId(string? adUnitId)
     {
+#if ANDROID || IOS
         if (AdConfig.UseTestAdUnitIds)
         {
             return AdMobTestAdUnits.Rewarded;
         }
+#endif
 
         return adUnitId ?? AdConfig.DefaultRewardedAdUnitId;
     }

--- a/src/Plugin.AdMob/Services/RewardedInterstitialAdService.cs
+++ b/src/Plugin.AdMob/Services/RewardedInterstitialAdService.cs
@@ -94,10 +94,12 @@ internal class RewardedInterstitialAdService(IAdConsentService _adConsentService
     
     private static string? GetAdUnitId(string? adUnitId)
     {
+#if ANDROID || IOS
         if (AdConfig.UseTestAdUnitIds)
         {
             return AdMobTestAdUnits.RewardedInterstitial;
         }
+#endif
 
         return adUnitId ?? AdConfig.DefaultRewardedInterstitialAdUnitId;
     }


### PR DESCRIPTION
Currently if you try and use the plugin in a blank new MAUI project, you cannot do if without conditional compilations. This is not ideal, and could lead to some devs not using the plugin.

Errors:

`'MauiAppBuilder' does not contain a definition for 'UseAdMob' and no accessible extension method 'UseAdMob' accepting a first argument of type 'MauiAppBuilder' could be found (are you missing a using directive or an assembly reference?)`

`The type or namespace name 'Plugin' could not be found (are you missing a using directive or an assembly reference?)`