### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: Release
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   NuGetDirectory: ${{ github.workspace}}/nuget
 


### PR DESCRIPTION
Potential fix for [https://github.com/marius-bughiu/Plugin.AdMob/security/code-scanning/2](https://github.com/marius-bughiu/Plugin.AdMob/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves actions like checking out the repository, building, and publishing a NuGet package, we will assign the least privileges required for these tasks. Specifically:
- The `contents: read` permission is needed for the `actions/checkout` step.
- The `packages: write` permission is required for publishing the NuGet package.

We will add the `permissions` block at the root level of the workflow to apply it to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
