### PR TITLE
Follow-ups that missed the #88 squash: sample title + emulator troubleshooting docs

### DIFF
--- a/docs/Troubleshooting-Ads-not-showing.md
+++ b/docs/Troubleshooting-Ads-not-showing.md
@@ -21,6 +21,10 @@ For new apps / new or re-activated AdMob accounts, it can take time for real ads
 
 - [`#11`](https://github.com/marius-bughiu/Plugin.AdMob/issues/11) (real ads not showing; resolved after AdMob account/app became ready)
 
+## Full-screen test ads fail on an Android emulator (banners work)
+
+Interstitial, rewarded, and app open test ads can fail with `Ad failed to load : 3` ("No fill.") on emulators running with software GPU rendering, while banner test ads load fine. Run the emulator with hardware graphics acceleration. See [Troubleshooting-Android](Troubleshooting-Android.md#full-screen-test-ads-fail-with-no-fill-on-emulators-banners-work) for details.
+
 ## Ads not loading in sample or on real device
 
 ### Symptoms

--- a/docs/Troubleshooting-Android.md
+++ b/docs/Troubleshooting-Android.md
@@ -50,6 +50,30 @@ Make sure your app explicitly sets a minimum Android platform version compatible
 
 - [`#68`](https://github.com/marius-bughiu/Plugin.AdMob/issues/68) (namespace warnings when min platform is too low)
 
+## Full-screen test ads fail with "no fill" on emulators (banners work)
+
+### Symptoms
+
+- Interstitial, rewarded, rewarded interstitial, and app open test ads fail to load with `Ad failed to load : 3` ("No fill.") on an Android emulator, while banner test ads load and render fine.
+- Consent is granted and `AdConfig.UseTestAdUnitIds = true`, so a fill is expected every time.
+- The full `LoadAdError` response shows the demo campaign *was* served, but the adapter failed instantly:
+
+```
+"Ad Source Instance Name": "[DO NOT EDIT] Publisher Test Interstitial",
+"Ad Error": { "Code": 0, "Message": "Internal error.", ... },
+"Latency": 0
+```
+
+### Root cause
+
+The emulator is running with software GPU rendering (`-gpu swiftshader_indirect`, or "Graphics: Software" in the AVD settings). Full-screen ad creatives are pre-rendered at load time and fail with an internal error without hardware acceleration. The SDK surfaces this as a generic no-fill. Banner ads are not affected, which makes it look like an ad-serving or plugin problem when it is not.
+
+### Fix / mitigation
+
+- Start the emulator with hardware graphics acceleration: `emulator -avd <name> -gpu host`, or set **Graphics: Hardware** in the AVD settings in Android Studio.
+- To see the underlying error instead of a bare "no fill", subscribe to `OnAdFailedToLoad` on the ad or ad service and log the message.
+- Physical devices are unaffected.
+
 ## Runtime errors on older Android versions
 
 ### Symptoms

--- a/docs/Troubleshooting-Android.md
+++ b/docs/Troubleshooting-Android.md
@@ -74,6 +74,10 @@ The emulator is running with software GPU rendering (`-gpu swiftshader_indirect`
 - To see the underlying error instead of a bare "no fill", subscribe to `OnAdFailedToLoad` on the ad or ad service and log the message.
 - Physical devices are unaffected.
 
+## Native test ads fail on emulators without the Play Store
+
+Native test ads fail with `Ad failed to load : 0` and `Incorrect native ad response. Click actions were not properly specified` on **Google APIs** emulator images: the native demo campaign serves app-install creatives whose click actions need the Play Store. Use a **Google Play** system image. See [Troubleshooting-Native-ads](Troubleshooting-Native-ads.md#native-test-ads-fail-on-android-emulators-without-the-play-store) for details.
+
 ## Runtime errors on older Android versions
 
 ### Symptoms

--- a/docs/Troubleshooting-Interstitial-ads.md
+++ b/docs/Troubleshooting-Interstitial-ads.md
@@ -20,6 +20,10 @@ An interstitial only shows after it has loaded. If you call `ShowAd()` while no 
 
 - [`#31`](https://github.com/marius-bughiu/Plugin.AdMob/issues/31) (request for load state tracking; the service now exposes `IsAdLoaded`)
 
+## Test interstitials fail with "no fill" on an Android emulator
+
+Full-screen test ads (interstitial, rewarded, app open) can fail with `Ad failed to load : 3` on emulators running with software GPU rendering, while banner test ads work fine. See [Troubleshooting-Android](Troubleshooting-Android.md#full-screen-test-ads-fail-with-no-fill-on-emulators-banners-work).
+
 ## Interstitial does not show while a MAUI modal is open (iOS)
 
 ### Symptoms

--- a/docs/Troubleshooting-Native-ads.md
+++ b/docs/Troubleshooting-Native-ads.md
@@ -22,3 +22,26 @@
 
 - [`#66`](https://github.com/marius-bughiu/Plugin.AdMob/issues/66) (native ads gated by consent)
 
+## Native test ads fail on Android emulators without the Play Store
+
+### Symptoms
+
+- Native test ads fail with `Ad failed to load : 0` on an Android emulator, while banner test ads work.
+- Logcat shows:
+
+```
+Received log message: <Google:HTML> Incorrect native ad response. Click actions were not properly specified
+```
+
+- The full `LoadAdError` response shows the demo campaign *was* served (`"Ad Source Instance Name": "[DevRel] [DO NOT EDIT] Native Ads Campaign"`, `"app_promotion_type": "INSTALL"`) but the SDK rejected it.
+
+### Root cause
+
+The native demo campaign serves app-install creatives whose click actions target the Play Store (`market://` links). On emulator images without the Play Store (**Google APIs** images, as opposed to **Google Play** images), those click actions cannot be resolved, so the SDK rejects the response.
+
+### Fix / mitigation
+
+- Use an emulator image that includes the Play Store (a **Google Play** system image, e.g. `system-images;android-36;google_apis_playstore;x86_64`).
+- Physical devices with the Play Store are unaffected.
+- On Android versions of the plugin before the native ad unit fix, also make sure you are on a plugin version where `NativeAdView` uses `AdConfig.DefaultNativeAdUnitId` (not the banner default) when no `AdUnitId` is set.
+

--- a/docs/Troubleshooting-Native-ads.md
+++ b/docs/Troubleshooting-Native-ads.md
@@ -43,5 +43,4 @@ The native demo campaign serves app-install creatives whose click actions target
 
 - Use an emulator image that includes the Play Store (a **Google Play** system image, e.g. `system-images;android-36;google_apis_playstore;x86_64`).
 - Physical devices with the Play Store are unaffected.
-- On Android versions of the plugin before the native ad unit fix, also make sure you are on a plugin version where `NativeAdView` uses `AdConfig.DefaultNativeAdUnitId` (not the banner default) when no `AdUnitId` is set.
 

--- a/samples/Foo.Bar.SampleApp/AppShell.xaml
+++ b/samples/Foo.Bar.SampleApp/AppShell.xaml
@@ -8,7 +8,7 @@
     Title="Foo.Bar.SampleApp">
 
     <ShellContent
-        Title="Plugin.AdMob Sample"
+        x:Name="MainShellContent"
         ContentTemplate="{DataTemplate local:MainPage}"
         Route="MainPage" />
 

--- a/samples/Foo.Bar.SampleApp/AppShell.xaml
+++ b/samples/Foo.Bar.SampleApp/AppShell.xaml
@@ -8,7 +8,7 @@
     Title="Foo.Bar.SampleApp">
 
     <ShellContent
-        Title="NET10"
+        Title="Plugin.AdMob Sample"
         ContentTemplate="{DataTemplate local:MainPage}"
         Route="MainPage" />
 

--- a/samples/Foo.Bar.SampleApp/AppShell.xaml.cs
+++ b/samples/Foo.Bar.SampleApp/AppShell.xaml.cs
@@ -1,10 +1,18 @@
-﻿namespace Foo.Bar.SampleApp
+﻿using System.Reflection;
+
+namespace Foo.Bar.SampleApp
 {
     public partial class AppShell : Shell
     {
         public AppShell()
         {
             InitializeComponent();
+
+            var mauiVersion = typeof(Shell).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion.Split('+')[0];
+
+            MainShellContent.Title = $"MAUI {mauiVersion}";
         }
     }
 }

--- a/src/Plugin.AdMob/Platforms/Android/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/Android/Native/NativeAdHandler.cs
@@ -94,10 +94,10 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
     {
         if (AdConfig.UseTestAdUnitIds)
         {
-            return AdMobTestAdUnits.Banner;
+            return AdMobTestAdUnits.Native;
         }
 
-        return VirtualView.AdUnitId ?? AdConfig.DefaultBannerAdUnitId;
+        return VirtualView.AdUnitId ?? AdConfig.DefaultNativeAdUnitId;
     }
 
     private void OnConsentInfoUpdated(object? sender, IConsentInformation? e)


### PR DESCRIPTION
## Summary

Follow-ups from live-testing #88 on an emulator, plus two commits that were pushed to `net10-only` after it was already squash-merged:

- **Sample shell title**: now shows the running MAUI version (read from the `Microsoft.Maui.Controls` assembly at runtime), e.g. "MAUI 10.0.30".
- **Fix: Android `NativeAdView` used banner ad units.** The Android handler requested the *banner* test ad unit in test mode and fell back to `DefaultBannerAdUnitId` in production, so native requests went to banner ad units and were rejected with `Incorrect native ad response. Click actions were not properly specified` / `Ad failed to load : 0`. Now uses the native test unit and `DefaultNativeAdUnitId`, matching iOS.
- **Troubleshooting docs** (diagnosed live on API 36 emulators):
  - Full-screen test ads (interstitial/rewarded/app open) fail with no-fill on emulators using software GPU rendering — run the emulator with hardware graphics acceleration (`-gpu host`).
  - Native test ads fail on emulator images without the Play Store — the native demo campaign serves app-install creatives whose click actions target `market://` links. Use a Google Play system image.

## Verification

Verified on an API 36 emulator (`google_apis_playstore` image, host GPU): banner, interstitial, and native ads (both the XAML `NativeAdView` path and the `INativeAdService.CreateAd` path) all load and render with test ad units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)