### PR TITLE
Dependency updates wave 1: build tooling (MinVer 7)

### DIFF
--- a/src/Plugin.AdMob/Plugin.AdMob.csproj
+++ b/src/Plugin.AdMob/Plugin.AdMob.csproj
@@ -61,7 +61,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MinVer" Version="6.0.0">
+		<PackageReference Include="MinVer" Version="7.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## Summary

First of four dependency-update waves (build tooling → plugin ad SDK bindings → sample packages → MAUI).

- **MinVer**: 6.0.0 → 7.0.0

MinVer is build-time only (`PrivateAssets=all`), so there is no runtime impact on the plugin or apps.

## Verification

- Untagged Release pack → `Plugin.AdMob.10.0.30-beta.2.nupkg`
- With a `v10.0.30.99` tag on HEAD → `Plugin.AdMob.10.0.30.99.nupkg`
- Both sample apps deployed to an API 36 emulator (Google Play image) and manually tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)