### PR TITLE
Dependency updates wave 2: Google ad SDK bindings

### DIFF
--- a/samples/Foo.Bar.SampleApp.Hybrid/Foo.Bar.SampleApp.Hybrid.csproj
+++ b/samples/Foo.Bar.SampleApp.Hybrid/Foo.Bar.SampleApp.Hybrid.csproj
@@ -45,6 +45,11 @@
         <SupportedOSPlatformVersion>23.0</SupportedOSPlatformVersion>
     </PropertyGroup>
 
+    <!-- Jc.UMP.iOS 2.7.5 buildTransitive targets fail unless SupportedOSPlatformVersion is set explicitly -->
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
+        <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+    </PropertyGroup>
+
     <!-- See: https://github.com/marius-bughiu/Plugin.AdMob/issues/67 -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
         <PackageReference Include="Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm" Version="1.10.0.1" ExcludeAssets="all" />

--- a/samples/Foo.Bar.SampleApp/Foo.Bar.SampleApp.csproj
+++ b/samples/Foo.Bar.SampleApp/Foo.Bar.SampleApp.csproj
@@ -25,6 +25,11 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
 		<SupportedOSPlatformVersion>23.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
+
+	<!-- Jc.UMP.iOS 2.7.5 buildTransitive targets fail unless SupportedOSPlatformVersion is set explicitly -->
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
+		<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+	</PropertyGroup>
 	
 	<!-- See: https://github.com/marius-bughiu/Plugin.AdMob/issues/67 -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">

--- a/src/Plugin.AdMob/Plugin.AdMob.csproj
+++ b/src/Plugin.AdMob/Plugin.AdMob.csproj
@@ -73,12 +73,12 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
-		<PackageReference Include="Xamarin.GooglePlayServices.Ads.Lite" Version="124.0.0.4" />
+		<PackageReference Include="Xamarin.GooglePlayServices.Ads.Lite" Version="124.0.0.6" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
-		<PackageReference Include="Jc.GMA.iOS" Version="12.2.1" />
-		<PackageReference Include="Jc.UMP.iOS" Version="2.7.3" />
+		<PackageReference Include="Jc.GMA.iOS" Version="12.7.1" />
+		<PackageReference Include="Jc.UMP.iOS" Version="2.7.5" />
 	</ItemGroup>
 
 	<Target Name="ApplyMauiTrackedVersion" AfterTargets="MinVer" Condition="'$(MinVerSkip)' != 'true'">


### PR DESCRIPTION
## Summary

Second of four dependency-update waves (build tooling → **plugin ad SDK bindings** → sample packages → MAUI).

- **Xamarin.GooglePlayServices.Ads.Lite** (Android): 124.0.0.4 → 124.0.0.6
- **Jc.GMA.iOS**: 12.2.1 → 12.7.1
- **Jc.UMP.iOS**: 2.7.3 → 2.7.5

## Verification

- Plugin builds clean on all TFMs (android/ios/maccatalyst/windows) — no binding surface breaks from GMA iOS 12.7.
- Both sample apps deployed to an API 36 emulator (Google Play image) and manually tested: consent flow, banners, native, and full-screen formats.
- iOS packages are compile-verified only; runtime verification on iOS pending a Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)