### PR TITLE
Dependency updates wave 4: .NET MAUI 10.0.80

### DIFF
--- a/samples/Foo.Bar.SampleApp.Hybrid/Foo.Bar.SampleApp.Hybrid.csproj
+++ b/samples/Foo.Bar.SampleApp.Hybrid/Foo.Bar.SampleApp.Hybrid.csproj
@@ -50,16 +50,11 @@
         <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     </PropertyGroup>
 
-    <!-- See: https://github.com/marius-bughiu/Plugin.AdMob/issues/67 -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
-        <PackageReference Include="Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm" Version="1.10.0.1" ExcludeAssets="all" />
-    </ItemGroup>
-
     <ItemGroup>
-        <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.30" />
-        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.30" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.30" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.2" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.80" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.80" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.80" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
     </ItemGroup>
 
 	<ItemGroup>

--- a/samples/Foo.Bar.SampleApp/Foo.Bar.SampleApp.csproj
+++ b/samples/Foo.Bar.SampleApp/Foo.Bar.SampleApp.csproj
@@ -31,11 +31,6 @@
 		<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 	
-	<!-- See: https://github.com/marius-bughiu/Plugin.AdMob/issues/67 -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
-		<PackageReference Include="Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm" Version="1.10.0.1" ExcludeAssets="all" />
-	</ItemGroup>
-
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
@@ -55,9 +50,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.30" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.30" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.80" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.80" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Plugin.AdMob/Plugin.AdMob.csproj
+++ b/src/Plugin.AdMob/Plugin.AdMob.csproj
@@ -27,7 +27,7 @@
 			Release builds ($(MauiPackageVersion)-beta.<height>). Debug builds are versioned
 			$(MauiPackageVersion)-dev.<timestamp>.
 		-->
-		<MauiPackageVersion>10.0.30</MauiPackageVersion>
+		<MauiPackageVersion>10.0.80</MauiPackageVersion>
 		<MinVerTagPrefix>v</MinVerTagPrefix>
 		<MinVerDefaultPreReleaseIdentifiers>beta</MinVerDefaultPreReleaseIdentifiers>
 		<MinVerSkip Condition="'$(Configuration)' == 'Debug'">true</MinVerSkip>


### PR DESCRIPTION
## Summary

Final dependency-update wave (build tooling → ad SDK bindings → **MAUI + remaining packages**).

- **MauiPackageVersion**: 10.0.30 → 10.0.80 — by design this bumps the plugin package version; the next release tag should be `v10.0.80.<build>` (e.g. `v10.0.80.0` or `v10.0.80.1`).
- **Microsoft.Maui.Controls / Controls.Compatibility**: 10.0.30 → 10.0.80 (plugin via `MauiPackageVersion`, samples explicitly)
- **Microsoft.AspNetCore.Components.WebView.Maui** (Hybrid sample): 10.0.30 → 10.0.80
- **Microsoft.Extensions.Logging.Debug** (both samples): 10.0.2 → 10.0.9 (carried over from the skipped sample-packages wave)
- **Removed the #67 workaround** (`Xamarin.AndroidX.Compose.Runtime.Annotation.Jvm` with `ExcludeAssets="all"`) from both samples — verified no duplicate-class D8 failures on MAUI 10.0.80.

## Verification

- Plugin builds clean on all TFMs (android/ios/maccatalyst/windows).
- Both sample apps deployed to an API 36 emulator (Google Play image) and manually tested: consent, banners, native, and full-screen formats (interstitial test ad confirmed rendering).
- Sample title bar displays "MAUI 10.0.80" via the runtime version readout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)