### PR TITLE
Note that the duplicate Compose classes issue is fixed in MAUI 10.0.80

### DIFF
--- a/docs/Troubleshooting-Android.md
+++ b/docs/Troubleshooting-Android.md
@@ -14,7 +14,7 @@
   - Clean the solution
   - Delete `bin` and `obj`
   - Rebuild
-- **If you use .NET 10 and hit duplicate Compose annotation classes** (see closed issue #67), exclude the JVM variant from your app project:
+- **If you use .NET 10 and hit duplicate Compose annotation classes** (see closed issue #67): this is fixed in .NET MAUI 10.0.80 — update `Microsoft.Maui.Controls` to 10.0.80 or later and remove the workaround. On older MAUI 10 versions, exclude the JVM variant from your app project:
 
 ```
 <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">


### PR DESCRIPTION
## Summary

Docs-only follow-up that missed the #92 squash: updates the issue #67 entry in `Troubleshooting-Android.md` to say the duplicate Compose annotation classes problem is fixed as of .NET MAUI 10.0.80 (matching the workaround removal from the samples in #92), while keeping the exclusion snippet for anyone on older MAUI 10 versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)