### PR TITLE
Fix native ads not taking up layout space on iOS

### DIFF
--- a/src/Plugin.AdMob/Platforms/iOS/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/iOS/Native/NativeAdHandler.cs
@@ -8,7 +8,11 @@ namespace Plugin.AdMob.Handlers;
 
 internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.MobileAds.NativeAdView>
 {
+    // Insets applied by the constraints pinning the ad content inside the platform view.
+    private const double ContentInset = 8;
+
     private IAdConsentService? _adConsentService;
+    private bool _adContentAttached;
 
     public static IPropertyMapper<NativeAdView, NativeAdHandler> PropertyMapper
         = new PropertyMapper<NativeAdView, NativeAdHandler>(ViewMapper);
@@ -89,24 +93,45 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.Mobile
         this.VirtualView.AdContent.BindingContext = ad;
 
         var adContentView = this.VirtualView.AdContent.ToPlatform(MauiContext);
-        PlatformView.TranslatesAutoresizingMaskIntoConstraints = false;
+
+        // The platform view is positioned by MAUI via its Frame, so it must keep
+        // TranslatesAutoresizingMaskIntoConstraints = true; only the embedded ad
+        // content participates in Auto Layout.
+        adContentView.TranslatesAutoresizingMaskIntoConstraints = false;
 
         PlatformView.AddSubview(adContentView);
 
         NSLayoutConstraint.ActivateConstraints(new[]
         {
-            // Pin the label's top/left to container
-            adContentView.TopAnchor.ConstraintEqualTo(PlatformView.TopAnchor, 8),
-            adContentView.LeadingAnchor.ConstraintEqualTo(PlatformView.LeadingAnchor, 8),
-            
-            // Make the container expand by pinning container’s bottom/trailing 
-            // to label’s bottom/trailing
-            PlatformView.BottomAnchor.ConstraintEqualTo(adContentView.BottomAnchor, 8),
-            PlatformView.TrailingAnchor.ConstraintEqualTo(adContentView.TrailingAnchor, 8),
+            adContentView.TopAnchor.ConstraintEqualTo(PlatformView.TopAnchor, (nfloat)ContentInset),
+            adContentView.LeadingAnchor.ConstraintEqualTo(PlatformView.LeadingAnchor, (nfloat)ContentInset),
+            PlatformView.BottomAnchor.ConstraintEqualTo(adContentView.BottomAnchor, (nfloat)ContentInset),
+            PlatformView.TrailingAnchor.ConstraintEqualTo(adContentView.TrailingAnchor, (nfloat)ContentInset),
         });
 
         PlatformView.NativeAd = ((NativeAd)ad).GetPlatformAd();
         VirtualView.BindingContext = ad;
+
+        _adContentAttached = true;
+        ((IView)VirtualView).InvalidateMeasure();
+    }
+
+    // Google.MobileAds.NativeAdView is a plain UIView whose SizeThatFits reports its
+    // current (initially zero) bounds, so MAUI must be given the ad content's size.
+    public override Microsoft.Maui.Graphics.Size GetDesiredSize(double widthConstraint, double heightConstraint)
+    {
+        if (!_adContentAttached)
+        {
+            return base.GetDesiredSize(widthConstraint, heightConstraint);
+        }
+
+        var contentSize = ((IView)VirtualView.AdContent).Measure(
+            Math.Max(0, widthConstraint - 2 * ContentInset),
+            Math.Max(0, heightConstraint - 2 * ContentInset));
+
+        return new Microsoft.Maui.Graphics.Size(
+            contentSize.Width + 2 * ContentInset,
+            contentSize.Height + 2 * ContentInset);
     }
 
     private void RegisterEventHandlers(INativeAd ad)


### PR DESCRIPTION
## Problem

On iOS, native ads rendered but occupied zero height in the MAUI layout — sibling controls were positioned on top of the ad content.

## Root cause

Three compounding issues in the iOS `NativeAdHandler`:

1. **MAUI never learned the ad's size.** `GADNativeAdView` is a plain `UIView` that doesn't override `sizeThatFits:`, so UIKit's default returned its current (zero) bounds, and the handler didn't override `GetDesiredSize`. The Auto Layout constraints added in `ShowAd` are invisible to MAUI's measure pass, which uses manual frame layout.
2. **Inverted `TranslatesAutoresizingMaskIntoConstraints`.** It was set to `false` on the platform view (which MAUI positions by assigning `Frame`) and left `true` on the embedded ad content that the pin constraints reference. The content therefore drew at the constraint-resolved size outside its zero-height layout slot (UIView doesn't clip subviews by default) — "renders but takes no space".
3. **No re-measure after async ad load.** Nothing invalidated the virtual view's measure when the ad content was attached after the initial layout pass.

Android was unaffected because its `NativeAdView` is a `FrameLayout": MAUI's default measure calls `platformView.Measure` which sizes the children, and `AddView` triggers `requestLayout`.

## Fix

- Override `GetDesiredSize` to measure the MAUI `AdContent` cross-platform and report its size plus the 8pt pin-constraint insets
- Keep the platform view frame-positioned (TAMIC stays `true`); set TAMIC `false` on the embedded ad content instead
- Call `InvalidateMeasure()` on the virtual view once the ad content is attached

## Verification

Tested on a physical iPhone 15 (iOS 26.5) with the sample app's native ads page, logging layout frames after ad load: each `NativeAdView` now measures 216pt tall (200pt template + 2×8pt insets) and controls added after it are positioned below it (e.g. ad at Y=76 H=216, next control at Y=308), including with multiple stacked ads. Before the fix all ads measured 0pt and siblings overlapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)