### PR TITLE
Document the verified fix for Firebase duplicate measurement classes

### DIFF
--- a/docs/Troubleshooting-Android.md
+++ b/docs/Troubleshooting-Android.md
@@ -22,7 +22,15 @@
 </ItemGroup>
 ```
 
-- **If you use Firebase and hit duplicate Google measurement classes** (see closed issue #29): this is usually a dependency graph conflict. After cleaning, you may need to pin or exclude the offending transitive package versions in your app.
+- **If you use Firebase and hit duplicate Google measurement classes** (see issues #29 and #55, e.g. `Type com.google.android.gms.internal.measurement.zzbm is defined multiple times`): the Google "measurement" classes ship in both `Xamarin.GooglePlayServices.Measurement.*` (pulled in by this plugin via `Xamarin.GooglePlayServices.Ads.Lite`) and `Xamarin.Firebase.Analytics` (pulled in by Plugin.Firebase). The build only works when the whole family resolves to the same Google release train. Align them by referencing `Xamarin.Firebase.Analytics` directly in your app at the version matching the resolved `Xamarin.GooglePlayServices.Measurement.Base` (check `obj/project.assets.json`). Verified with Plugin.Firebase 4.2.1 and Xamarin.GooglePlayServices.Ads.Lite 124.0.0.6:
+
+```
+<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
+	<PackageReference Include="Xamarin.Firebase.Analytics" Version="123.2.0.1" />
+</ItemGroup>
+```
+
+  Note: enabling MultiDex or switching to d8/r8 does **not** fix this — d8/r8 fail on duplicate type definitions rather than deduplicating them.
 
 ### Related issues
 


### PR DESCRIPTION
## Summary

Replaces the vague "pin or exclude the offending transitive package versions" guidance with the concrete, verified fix for the Plugin.Firebase + Plugin.AdMob duplicate-classes build failure.

Reproduced today with Plugin.Firebase 4.2.1 + current main (Ads.Lite 124.0.0.6): `Type com.google.android.gms.internal.measurement.zzbm is defined multiple times`. The colliding libraries are `com.google.android.gms.measurement_base` (from Xamarin.GooglePlayServices.Measurement.Base 123.2.0.1, via Ads.Lite) and `com.google.firebase.measurement` (from Xamarin.Firebase.Analytics 122.0.2.1, via Plugin.Firebase) — the same classes from two different Google release trains.

**Verified fix** (build goes from failing to succeeding):

```xml
<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
    <PackageReference Include="Xamarin.Firebase.Analytics" Version="123.2.0.1" />
</ItemGroup>
```

Also documents that MultiDex/d8/r8 settings do **not** fix this (tested — d8/r8 fail on duplicate definitions rather than deduplicating), which is why #71 is being closed in favor of this documentation.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)