### PR TITLE
Document minimum OS version requirements (Android 23, iOS 15.0)

### DIFF
--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -32,6 +32,14 @@ You need to update your app's manifest (`Platforms/Android/AndroidManifest.xml`)
 </manifest>
 ```
 
+Set the minimum supported Android version to **23** in your app's `.csproj` — Google Play Services requires it, and lower values cause manifest merger errors on .NET 10 (see [Troubleshooting-Android](Troubleshooting-Android.md#androidmanifest-namespace-warnings-on-net-10--api-35)):
+
+```
+<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
+	<SupportedOSPlatformVersion>23.0</SupportedOSPlatformVersion>
+</PropertyGroup>
+```
+
 For more details you can check the official docs: [Get started with AdMob on Android](https://developers.google.com/admob/android/quick-start)
 
 For a fully working example, check out the [samples folder](https://github.com/marius-bughiu/Plugin.AdMob/tree/main/samples).
@@ -82,6 +90,21 @@ public class AppDelegate : MauiUIApplicationDelegate
         <_CustomLinkFlags Include="-Wl,/usr/lib/swift" />
     </ItemGroup>
 </Target>
+```
+
+5. Set the minimum supported iOS version to **15.0** — the Google Mobile Ads SDK requires it. Without it, `MobileAds.SharedInstance.Start(...)` can fail with a `NullReferenceException` on physical devices (see issue #56), and the `Jc.UMP.iOS` build targets fail unless `SupportedOSPlatformVersion` is set explicitly. In your app's `.csproj`:
+
+```
+<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
+	<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+</PropertyGroup>
+```
+
+Also add the matching key to your `Platforms/iOS/Info.plist` — Release builds fail without it:
+
+```
+<key>MinimumOSVersion</key>
+<string>15.0</string>
 ```
 
 For a fully working example, check out the [samples folder](https://github.com/marius-bughiu/Plugin.AdMob/tree/main/samples).

--- a/docs/Troubleshooting-iOS.md
+++ b/docs/Troubleshooting-iOS.md
@@ -27,6 +27,38 @@ Google.MobileAds.MobileAds.SharedInstance.Start(completionHandler: null);
 - [`#21`](https://github.com/marius-bughiu/Plugin.AdMob/issues/21) (iOS crash with `GADInvalidInitializationException`)
 - [`#58`](https://github.com/marius-bughiu/Plugin.AdMob/issues/58) (TestFlight crash; typically points to iOS configuration differences between debug and distribution)
 
+## NullReferenceException from `MobileAds.SharedInstance.Start(...)` on a physical device
+
+### Symptoms
+
+- `An error occurred: 'Object reference not set to an instance of an object.'` thrown from `AppDelegate.CreateMauiApp()` at the `Google.MobileAds.MobileAds.SharedInstance.Start(...)` call.
+- Typically reproduces on a physical device; the simulator may appear fine.
+
+### Root cause
+
+The app's minimum iOS version is below what the Google Mobile Ads SDK supports (15.0). The `Jc.GMA.iOS` binding also declares this requirement.
+
+### Fix / mitigation
+
+Set the minimum supported iOS version to 15.0 in your app's `.csproj`:
+
+```
+<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
+	<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+</PropertyGroup>
+```
+
+and add the matching key to `Platforms/iOS/Info.plist` (Release builds fail without it):
+
+```
+<key>MinimumOSVersion</key>
+<string>15.0</string>
+```
+
+### Related issues
+
+- [`#56`](https://github.com/marius-bughiu/Plugin.AdMob/issues/56) (null reference on physical device when the minimum OS version is too low)
+
 ## Banner view controller cannot be detected
 
 ### Symptoms


### PR DESCRIPTION
## Summary

Documents the minimum OS version requirements that the sample apps already carry (added in 7b8043c) but the docs never stated:

- **Setup → Android**: `SupportedOSPlatformVersion` 23 — required by Google Play Services; lower values cause manifest merger errors on .NET 10 (#68, also confirmed while investigating #62).
- **Setup → iOS**: new step 5 — `SupportedOSPlatformVersion` 15.0 (Google Mobile Ads SDK requirement; also required for the `Jc.UMP.iOS` build targets) plus `MinimumOSVersion` in `Info.plist` for Release builds, exactly as suggested by @RicovanBuren in #56.
- **Troubleshooting (iOS)**: new entry for the #56 symptom — `NullReferenceException` from `MobileAds.SharedInstance.Start(...)` in `AppDelegate.CreateMauiApp()` on physical devices — with root cause and fix.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)