### PR TITLE
Prevent duplicate native ad loads from repeated consent updates

### DIFF
--- a/src/Plugin.AdMob/Platforms/Android/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/Android/Native/NativeAdHandler.cs
@@ -8,6 +8,7 @@ namespace Plugin.AdMob.Handlers;
 internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Android.Gms.Ads.NativeAd.NativeAdView>
 {
     private IAdConsentService? _adConsentService;
+    private bool _adContentAttached;
 
     public static IPropertyMapper<NativeAdView, NativeAdHandler> PropertyMapper =
         new PropertyMapper<NativeAdView, NativeAdHandler>(ViewMapper);
@@ -42,6 +43,7 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
             _adConsentService.OnConsentInfoUpdated -= OnConsentInfoUpdated;
         }
 
+        _adContentAttached = false;
         base.DisconnectHandler(platformView);
     }
 
@@ -71,6 +73,11 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
 
     private void ShowAd(INativeAd ad)
     {
+        if (_adContentAttached)
+        {
+            return;
+        }
+
         this.VirtualView.AdContent.BindingContext = ad;
 
         var adContentView = this.VirtualView.AdContent.ToPlatform(MauiContext!);
@@ -78,6 +85,8 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
 
         PlatformView.SetNativeAd(((NativeAd)ad).GetPlatformAd());
         VirtualView.BindingContext = ad;
+
+        _adContentAttached = true;
     }
 
     private void RegisterEventHandlers(INativeAd ad)
@@ -102,12 +111,19 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
 
     private void OnConsentInfoUpdated(object? sender, IConsentInformation? e)
     {
+        // Consent updates repeatedly (resets, privacy forms); load a single ad once consent allows it.
+        if (!AdConfig.DisableConsentCheck && _adConsentService?.CanRequestAds() is not true)
+        {
+            return;
+        }
+
         // Check if the handler is still connected before loading ad
         // In .NET MAUI 10+, PlatformView throws InvalidOperationException when disconnected
         try
         {
             if (PlatformView is not null)
             {
+                _adConsentService!.OnConsentInfoUpdated -= OnConsentInfoUpdated;
                 LoadAd();
             }
         }

--- a/src/Plugin.AdMob/Platforms/iOS/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/iOS/Native/NativeAdHandler.cs
@@ -26,6 +26,7 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.Mobile
         }
 
         platformView.Dispose();
+        _adContentAttached = false;
         base.DisconnectHandler(platformView);
     }
 
@@ -90,6 +91,11 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.Mobile
 
     private void ShowAd(INativeAd ad)
     {
+        if (_adContentAttached)
+        {
+            return;
+        }
+
         this.VirtualView.AdContent.BindingContext = ad;
 
         var adContentView = this.VirtualView.AdContent.ToPlatform(MauiContext);
@@ -156,12 +162,19 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.Mobile
 
     private void OnConsentInfoUpdated(object? sender, IConsentInformation? e)
     {
+        // Consent updates repeatedly (resets, privacy forms); load a single ad once consent allows it.
+        if (!AdConfig.DisableConsentCheck && _adConsentService?.CanRequestAds() is not true)
+        {
+            return;
+        }
+
         // Check if the handler is still connected before loading ad
         // In .NET MAUI 10+, PlatformView throws InvalidOperationException when disconnected
         try
         {
             if (PlatformView is not null)
             {
+                _adConsentService!.OnConsentInfoUpdated -= OnConsentInfoUpdated;
                 LoadAd();
             }
         }


### PR DESCRIPTION
## Problem

`ShowAd()` in the native ad handlers could run more than once for the same `NativeAdView`. Observed on a physical iPhone 15 (iOS 26.5) with console logging: two `ShowAd` invocations ~2.5s apart on the **same handler instance and same platform view**.

The trigger is the consent flow, not a handler disconnect/reconnect as initially suspected:

1. `AdConsentService.Reset()` raises `OnConsentInfoUpdated` (`status=Unknown, canRequestAds=False`) — the handler called `LoadAd()` without checking whether ads could be requested → first ad → `ShowAd` #1.
2. When the consent flow completes, `OnConsentInfoUpdated` fires again (`status=Obtained, canRequestAds=True`) — the handler never unsubscribes, so it loaded a second ad → `ShowAd` #2. Any later consent update (privacy options form, another reset) repeats this.

Each extra `ShowAd` on iOS re-adds the ad content as a subview, activates a duplicate set of Auto Layout constraints (observed `constraints` going 0 → 14 on the second call), and re-assigns `PlatformView.NativeAd`, which resets the Google SDK's ad registration and restarts video playback. On Android the same sequence would throw `IllegalStateException`, because `AddView()` is called with a child that already has a parent.

## Fix (applied to both iOS and Android handlers)

- **`OnConsentInfoUpdated`** now ignores consent states that don't allow ad requests (honoring `AdConfig.DisableConsentCheck`) and unsubscribes before its single `LoadAd()`, so consent updates can load at most one ad per handler.
- **`ShowAd` is idempotent**: it returns early when the ad content is already attached (`_adContentAttached`, field added on Android). `DisconnectHandler` resets the flag so a reconnect with a fresh platform view still attaches correctly.

MacCatalyst/Windows handlers are stubs and unaffected.

## Verification

- Reproduced the double `ShowAd` on a physical iPhone 15 with the sample's MainPage XAML `NativeAdView` before the fix (log excerpt above).
- After the fix, on the iOS simulator with fresh consent state: the reset-triggered event is skipped, and the consent-granted event produces exactly one `LoadAd`/`ShowAd`; no further activity afterwards.
- Diagnostic logging used for the investigation has been removed; the diff contains only the fix.
- `net10.0-ios` builds clean (only the pre-existing `ToPlatform` nullability warning). No Android SDK on the dev machine, so the `net10.0-android` target relies on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)