### PR TITLE
Load native ads on Android when consent is already granted at connect

### DIFF
--- a/src/Plugin.AdMob/Platforms/Android/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/Android/Native/NativeAdHandler.cs
@@ -27,7 +27,15 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
         {
             _adConsentService = IPlatformApplication.Current!.Services
                 .GetRequiredService<IAdConsentService>();
-            _adConsentService.OnConsentInfoUpdated += OnConsentInfoUpdated;
+
+            if (CanRequestAds() is true)
+            {
+                LoadAd();
+            }
+            else
+            {
+                _adConsentService.OnConsentInfoUpdated += OnConsentInfoUpdated;
+            }
         }
         else
         {
@@ -109,10 +117,20 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
         return VirtualView.AdUnitId ?? AdConfig.DefaultNativeAdUnitId;
     }
 
+    private bool CanRequestAds()
+    {
+        if (AdConfig.DisableConsentCheck)
+        {
+            return true;
+        }
+
+        return _adConsentService?.CanRequestAds() ?? false;
+    }
+
     private void OnConsentInfoUpdated(object? sender, IConsentInformation? e)
     {
         // Consent updates repeatedly (resets, privacy forms); load a single ad once consent allows it.
-        if (!AdConfig.DisableConsentCheck && _adConsentService?.CanRequestAds() is not true)
+        if (CanRequestAds() is false)
         {
             return;
         }


### PR DESCRIPTION
## Problem

On Android, `NativeAdHandler.ConnectHandler` only subscribed to `IAdConsentService.OnConsentInfoUpdated` when no ad was preloaded — it never checked `CanRequestAds()` / `AdConfig.DisableConsentCheck`. A XAML-declared `NativeAdView` therefore only loaded if a consent event happened to fire *after* the handler connected.

With `UseAdMob(automaticallyAskForConsent: false)` and consent already obtained in a prior session — or a `NativeAdView` connected after the startup consent flow completed — no consent event ever fires post-connect, so the ad never loads on Android while the same page works on iOS.

## Fix

Align the Android `ConnectHandler` with its iOS counterpart (and with the consent gate the Android `BannerAdHandler` already applies): if `AdConfig.DisableConsentCheck` is set or `CanRequestAds()` returns true, call `LoadAd()` immediately; otherwise subscribe to `OnConsentInfoUpdated` as before. The `OnConsentInfoUpdated` handler (with its disconnected-handler guard) and the preloaded-ad path are unchanged.

## Verification

Compiled the `net10.0-android` target's C# (`-t:CoreCompile`) with zero errors; the only warnings are the two pre-existing ones in `BannerAdHandler`. The consent-gate logic is copied verbatim from the iOS `NativeAdHandler`, which already ships this behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)