### PR TITLE
Unsubscribe native ad events when the handler disconnects

### DIFF
--- a/src/Plugin.AdMob/Platforms/Android/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/Android/Native/NativeAdHandler.cs
@@ -10,6 +10,11 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
     private IAdConsentService? _adConsentService;
     private bool _adContentAttached;
 
+    // The ad outlives the handler on disconnect/reconnect, so the subscriptions
+    // made in RegisterEventHandlers must be removed to avoid raising events N times.
+    private INativeAd? _registeredAd;
+    private EventHandler<IAdError>? _onAdFailedToLoad;
+
     public static IPropertyMapper<NativeAdView, NativeAdHandler> PropertyMapper =
         new PropertyMapper<NativeAdView, NativeAdHandler>(ViewMapper);
 
@@ -50,6 +55,8 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
         {
             _adConsentService.OnConsentInfoUpdated -= OnConsentInfoUpdated;
         }
+
+        UnregisterEventHandlers();
 
         _adContentAttached = false;
         base.DisconnectHandler(platformView);
@@ -99,12 +106,36 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
 
     private void RegisterEventHandlers(INativeAd ad)
     {
-        ad.OnAdFailedToLoad += (s, e) => VirtualView.RaiseOnAdFailedToLoad(s, new AdError(e.Message));
+        UnregisterEventHandlers();
+
+        _onAdFailedToLoad = (s, e) => VirtualView.RaiseOnAdFailedToLoad(s, new AdError(e.Message));
+
+        ad.OnAdFailedToLoad += _onAdFailedToLoad;
         ad.OnAdImpression += VirtualView.RaiseOnAdImpression;
         ad.OnAdClicked += VirtualView.RaiseOnAdClicked;
         ad.OnAdSwiped += VirtualView.RaiseOnAdSwiped;
         ad.OnAdOpened += VirtualView.RaiseOnAdOpened;
         ad.OnAdClosed += VirtualView.RaiseOnAdClosed;
+
+        _registeredAd = ad;
+    }
+
+    private void UnregisterEventHandlers()
+    {
+        if (_registeredAd is null)
+        {
+            return;
+        }
+
+        _registeredAd.OnAdFailedToLoad -= _onAdFailedToLoad;
+        _registeredAd.OnAdImpression -= VirtualView.RaiseOnAdImpression;
+        _registeredAd.OnAdClicked -= VirtualView.RaiseOnAdClicked;
+        _registeredAd.OnAdSwiped -= VirtualView.RaiseOnAdSwiped;
+        _registeredAd.OnAdOpened -= VirtualView.RaiseOnAdOpened;
+        _registeredAd.OnAdClosed -= VirtualView.RaiseOnAdClosed;
+
+        _registeredAd = null;
+        _onAdFailedToLoad = null;
     }
 
     private string? GetAdUnitId()

--- a/src/Plugin.AdMob/Platforms/iOS/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/iOS/Native/NativeAdHandler.cs
@@ -14,6 +14,11 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.Mobile
     private IAdConsentService? _adConsentService;
     private bool _adContentAttached;
 
+    // The ad outlives the handler on disconnect/reconnect, so the subscriptions
+    // made in RegisterEventHandlers must be removed to avoid raising events N times.
+    private INativeAd? _registeredAd;
+    private EventHandler<IAdError>? _onAdFailedToLoad;
+
     public static IPropertyMapper<NativeAdView, NativeAdHandler> PropertyMapper
         = new PropertyMapper<NativeAdView, NativeAdHandler>(ViewMapper);
     public NativeAdHandler() : base(PropertyMapper) { }
@@ -24,6 +29,8 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.Mobile
         {
             _adConsentService.OnConsentInfoUpdated -= OnConsentInfoUpdated;
         }
+
+        UnregisterEventHandlers();
 
         platformView.Dispose();
         _adContentAttached = false;
@@ -142,12 +149,36 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.Mobile
 
     private void RegisterEventHandlers(INativeAd ad)
     {
-        ad.OnAdFailedToLoad += (s, e) => VirtualView.RaiseOnAdFailedToLoad(s, new AdError(e.Message));
+        UnregisterEventHandlers();
+
+        _onAdFailedToLoad = (s, e) => VirtualView.RaiseOnAdFailedToLoad(s, new AdError(e.Message));
+
+        ad.OnAdFailedToLoad += _onAdFailedToLoad;
         ad.OnAdImpression += VirtualView.RaiseOnAdImpression;
         ad.OnAdClicked += VirtualView.RaiseOnAdClicked;
         ad.OnAdSwiped += VirtualView.RaiseOnAdSwiped;
         ad.OnAdOpened += VirtualView.RaiseOnAdOpened;
         ad.OnAdClosed += VirtualView.RaiseOnAdClosed;
+
+        _registeredAd = ad;
+    }
+
+    private void UnregisterEventHandlers()
+    {
+        if (_registeredAd is null)
+        {
+            return;
+        }
+
+        _registeredAd.OnAdFailedToLoad -= _onAdFailedToLoad;
+        _registeredAd.OnAdImpression -= VirtualView.RaiseOnAdImpression;
+        _registeredAd.OnAdClicked -= VirtualView.RaiseOnAdClicked;
+        _registeredAd.OnAdSwiped -= VirtualView.RaiseOnAdSwiped;
+        _registeredAd.OnAdOpened -= VirtualView.RaiseOnAdOpened;
+        _registeredAd.OnAdClosed -= VirtualView.RaiseOnAdClosed;
+
+        _registeredAd = null;
+        _onAdFailedToLoad = null;
     }
 
     private string? GetAdUnitId()


### PR DESCRIPTION
## Problem

For pre-loaded ads (`NativeAdView` created with an existing `INativeAd`), `ConnectHandler` calls `RegisterEventHandlers(VirtualView._ad)` on every connect, but nothing ever unsubscribes. The ad outlives the handler, so each MAUI disconnect/reconnect cycle stacks another full set of subscriptions (`OnAdImpression`, `OnAdClicked`, `OnAdOpened`, `OnAdClosed`, `OnAdSwiped`, plus a new `OnAdFailedToLoad` lambda) onto the same ad instance — after N reconnects the app receives every ad event N times.

## Fix

Applied identically to the iOS and Android handlers:

- Track what was registered in two fields: `_registeredAd` (the ad subscribed to) and `_onAdFailedToLoad` (the previously-anonymous lambda, stored so it can be removed; the method-group handlers unsubscribe by target/method equality).
- `UnregisterEventHandlers()` removes all six subscriptions and clears the fields. It runs in `DisconnectHandler` (while `VirtualView` is still set, and before `platformView.Dispose()` on iOS) and defensively at the top of `RegisterEventHandlers`, so registration can never stack within one handler lifetime.

Since `LoadAd` shares `RegisterEventHandlers`, this also stops an ad abandoned by a disconnect mid-load from continuing to raise events into the view.

Complements #101 (ShowAd idempotency / consent-event double loads) and #102 (Android consent check at connect) — rebased on top of both; neither addressed the event subscription leak.

## Verification

- `dotnet build` succeeds for `net10.0-ios` / `net10.0-maccatalyst`.
- `net10.0-android` verified by invoking Roslyn directly with the restore's exact reference closure (no Android SDK/JDK on this machine): compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)