### PR TITLE
Unsubscribe the OnAdLoaded handler when the native ad handler disconnects

### DIFF
--- a/src/Plugin.AdMob/Platforms/Android/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/Android/Native/NativeAdHandler.cs
@@ -129,7 +129,11 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
             return;
         }
 
-        _registeredAd.OnAdLoaded -= _onAdLoaded;
+        if (_onAdLoaded is not null)
+        {
+            _registeredAd.OnAdLoaded -= _onAdLoaded;
+        }
+
         _registeredAd.OnAdFailedToLoad -= _onAdFailedToLoad;
         _registeredAd.OnAdImpression -= VirtualView.RaiseOnAdImpression;
         _registeredAd.OnAdClicked -= VirtualView.RaiseOnAdClicked;

--- a/src/Plugin.AdMob/Platforms/Android/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/Android/Native/NativeAdHandler.cs
@@ -13,6 +13,7 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
     // The ad outlives the handler on disconnect/reconnect, so the subscriptions
     // made in RegisterEventHandlers must be removed to avoid raising events N times.
     private INativeAd? _registeredAd;
+    private EventHandler? _onAdLoaded;
     private EventHandler<IAdError>? _onAdFailedToLoad;
 
     public static IPropertyMapper<NativeAdView, NativeAdHandler> PropertyMapper =
@@ -77,11 +78,12 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
         var ad = nativeAdService.CreateAd(adUnitId);
 
         RegisterEventHandlers(ad);
-        ad.OnAdLoaded += (s, e) =>
+        _onAdLoaded = (s, e) =>
         {
             VirtualView.RaiseOnAdLoaded(s, e);
             ShowAd(ad);
         };
+        ad.OnAdLoaded += _onAdLoaded;
 
         ad.Load();
     }
@@ -127,6 +129,7 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
             return;
         }
 
+        _registeredAd.OnAdLoaded -= _onAdLoaded;
         _registeredAd.OnAdFailedToLoad -= _onAdFailedToLoad;
         _registeredAd.OnAdImpression -= VirtualView.RaiseOnAdImpression;
         _registeredAd.OnAdClicked -= VirtualView.RaiseOnAdClicked;
@@ -135,6 +138,7 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, global::Andro
         _registeredAd.OnAdClosed -= VirtualView.RaiseOnAdClosed;
 
         _registeredAd = null;
+        _onAdLoaded = null;
         _onAdFailedToLoad = null;
     }
 

--- a/src/Plugin.AdMob/Platforms/iOS/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/iOS/Native/NativeAdHandler.cs
@@ -172,7 +172,11 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.Mobile
             return;
         }
 
-        _registeredAd.OnAdLoaded -= _onAdLoaded;
+        if (_onAdLoaded is not null)
+        {
+            _registeredAd.OnAdLoaded -= _onAdLoaded;
+        }
+
         _registeredAd.OnAdFailedToLoad -= _onAdFailedToLoad;
         _registeredAd.OnAdImpression -= VirtualView.RaiseOnAdImpression;
         _registeredAd.OnAdClicked -= VirtualView.RaiseOnAdClicked;

--- a/src/Plugin.AdMob/Platforms/iOS/Native/NativeAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/iOS/Native/NativeAdHandler.cs
@@ -17,6 +17,7 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.Mobile
     // The ad outlives the handler on disconnect/reconnect, so the subscriptions
     // made in RegisterEventHandlers must be removed to avoid raising events N times.
     private INativeAd? _registeredAd;
+    private EventHandler? _onAdLoaded;
     private EventHandler<IAdError>? _onAdFailedToLoad;
 
     public static IPropertyMapper<NativeAdView, NativeAdHandler> PropertyMapper
@@ -87,11 +88,12 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.Mobile
         var ad = nativeAdService.CreateAd(adUnitId);
 
         RegisterEventHandlers(ad);
-        ad.OnAdLoaded += (s, e) =>
+        _onAdLoaded = (s, e) =>
         {
             VirtualView.RaiseOnAdLoaded(s, e);
             ShowAd(ad);
         };
+        ad.OnAdLoaded += _onAdLoaded;
 
         ad.Load();
     }
@@ -170,6 +172,7 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.Mobile
             return;
         }
 
+        _registeredAd.OnAdLoaded -= _onAdLoaded;
         _registeredAd.OnAdFailedToLoad -= _onAdFailedToLoad;
         _registeredAd.OnAdImpression -= VirtualView.RaiseOnAdImpression;
         _registeredAd.OnAdClicked -= VirtualView.RaiseOnAdClicked;
@@ -178,6 +181,7 @@ internal partial class NativeAdHandler : ViewHandler<NativeAdView, Google.Mobile
         _registeredAd.OnAdClosed -= VirtualView.RaiseOnAdClosed;
 
         _registeredAd = null;
+        _onAdLoaded = null;
         _onAdFailedToLoad = null;
     }
 


### PR DESCRIPTION
## Summary

The `OnAdLoaded` lambda subscribed in `LoadAd()` was never removed on disconnect. If the MAUI handler disconnected while the ad was still loading, the lambda still fired when the load completed and called `VirtualView.RaiseOnAdLoaded` and `ShowAd` on a disconnected handler — accessing `PlatformView` there throws `InvalidOperationException` in .NET MAUI 10+, unhandled on the Google Mobile Ads SDK callback thread. The delegate also transiently kept the disconnected handler reachable.

This stores the delegate in an `_onAdLoaded` field and removes it in `UnregisterEventHandlers()`, mirroring the `_onAdFailedToLoad` pattern from #103. The subscription stays in `LoadAd()` rather than moving into `RegisterEventHandlers()` because it only applies to handler-initiated loads — the pre-created ad path (`NativeAdView(INativeAd, ContentView)`) shows the ad directly on connect. Applied identically to both platform handlers.

Flagged by Copilot review on #103 and deferred as out of scope there. Related prior fixes: #101 (ShowAd idempotency, consent-event gating), #103 (event subscription leak on disconnect/reconnect).

## Verification

- `dotnet build -f net10.0-ios` succeeds with 0 errors (only pre-existing warnings).
- The `net10.0-android` target cannot be built on this machine (no Android SDK), so the Android sources were compiled directly with Roslyn against the restore's `net10.0-android` reference closure (NuGet compile assets + `Microsoft.Android.Ref.36` / `Microsoft.NETCore.App.Ref` packs): 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)