### PR TITLE
Open automated PRs for new MAUI releases

### DIFF
--- a/.github/workflows/bump-maui.yml
+++ b/.github/workflows/bump-maui.yml
@@ -1,0 +1,69 @@
+name: Bump MAUI
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check NuGet for a newer MAUI release
+        id: check
+        run: |
+          current=$(sed -n 's:.*<MauiPackageVersion>\(.*\)</MauiPackageVersion>.*:\1:p' src/Plugin.AdMob/Plugin.AdMob.csproj)
+          major=${current%%.*}
+          latest=$(curl -sf https://api.nuget.org/v3-flatcontainer/microsoft.maui.controls/index.json |
+            jq -r --arg m "$major" '.versions[] | select(startswith($m + ".") and (contains("-") | not))' |
+            sort -V | tail -n 1)
+          [ -n "$current" ] && [ -n "$latest" ]
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          if [ "$latest" != "$current" ] && [ "$(printf '%s\n%s\n' "$current" "$latest" | sort -V | tail -n 1)" = "$latest" ]; then
+            echo "bump=true" >> "$GITHUB_OUTPUT"
+            echo "MAUI $current -> $latest"
+          else
+            echo "bump=false" >> "$GITHUB_OUTPUT"
+            echo "MAUI $current is up to date"
+          fi
+
+      - name: Apply the version bump
+        if: steps.check.outputs.bump == 'true'
+        env:
+          LATEST: ${{ steps.check.outputs.latest }}
+        run: |
+          sed -i -E "s|<MauiPackageVersion>[^<]+</MauiPackageVersion>|<MauiPackageVersion>$LATEST</MauiPackageVersion>|" \
+            src/Plugin.AdMob/Plugin.AdMob.csproj
+          sed -i -E \
+            -e "s|(Include=\"Microsoft\.Maui\.Controls\" Version=\")[^\"]+|\1$LATEST|" \
+            -e "s|(Include=\"Microsoft\.Maui\.Controls\.Compatibility\" Version=\")[^\"]+|\1$LATEST|" \
+            -e "s|(Include=\"Microsoft\.AspNetCore\.Components\.WebView\.Maui\" Version=\")[^\"]+|\1$LATEST|" \
+            samples/Foo.Bar.SampleApp/Foo.Bar.SampleApp.csproj \
+            samples/Foo.Bar.SampleApp.Hybrid/Foo.Bar.SampleApp.Hybrid.csproj
+          git diff --stat
+
+      - name: Open pull request
+        if: steps.check.outputs.bump == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: bump-maui-version
+          delete-branch: true
+          commit-message: Bump .NET MAUI to ${{ steps.check.outputs.latest }}
+          title: Bump .NET MAUI to ${{ steps.check.outputs.latest }}
+          body: |
+            Bumps .NET MAUI from `${{ steps.check.outputs.current }}` to `${{ steps.check.outputs.latest }}`.
+
+            Updates `MauiPackageVersion` in the plugin (which also becomes the next plugin package version) and the pinned MAUI packages in both sample apps.
+
+            Release notes: https://github.com/dotnet/maui/releases

--- a/.github/workflows/bump-maui.yml
+++ b/.github/workflows/bump-maui.yml
@@ -9,6 +9,9 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: bump-maui
+
 defaults:
   run:
     shell: bash
@@ -27,7 +30,10 @@ jobs:
           latest=$(curl -sf https://api.nuget.org/v3-flatcontainer/microsoft.maui.controls/index.json |
             jq -r --arg m "$major" '.versions[] | select(startswith($m + ".") and (contains("-") | not))' |
             sort -V | tail -n 1)
-          [ -n "$current" ] && [ -n "$latest" ]
+          if [ -z "$current" ] || [ -z "$latest" ]; then
+            echo "::error::Could not determine MAUI versions (current='$current', latest='$latest')"
+            exit 1
+          fi
           echo "current=$current" >> "$GITHUB_OUTPUT"
           echo "latest=$latest" >> "$GITHUB_OUTPUT"
           if [ "$latest" != "$current" ] && [ "$(printf '%s\n%s\n' "$current" "$latest" | sort -V | tail -n 1)" = "$latest" ]; then


### PR DESCRIPTION
## What

Adds a scheduled workflow (`bump-maui.yml`) that opens a version-bump PR whenever a new stable .NET MAUI release appears on NuGet.

## How it works

- Runs daily at 06:00 UTC (and on manual dispatch).
- Reads `MauiPackageVersion` from `src/Plugin.AdMob/Plugin.AdMob.csproj` and compares it with the latest stable `Microsoft.Maui.Controls` on NuGet. Prereleases are ignored, and only versions within the current major are considered — a new major implies TFM changes that should be handled manually.
- On a newer version, it bumps everything in lockstep: `MauiPackageVersion` (which also becomes the next plugin package version) and the pinned `Microsoft.Maui.Controls`, `Microsoft.Maui.Controls.Compatibility`, and `Microsoft.AspNetCore.Components.WebView.Maui` references in both sample apps.
- Opens a PR via `peter-evans/create-pull-request` on a fixed `bump-maui-version` branch, so a second service release while a bump PR is open updates the existing PR instead of stacking a new one. The branch is deleted after merge.

## Why not Dependabot

Dependabot files per-package PRs and doesn't reliably keep a custom MSBuild property and the samples' literal pins moving together. This bump is semantically one change — "track the new MAUI version" — so a single atomic PR fits better.

## Setup required

One repo setting must be enabled for the workflow to create PRs with the default `GITHUB_TOKEN`:
**Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"**

## Verification

- NuGet query tested against the live API: returns `10.0.80`, matching the current pin, so first runs correctly no-op.
- Sed replacements dry-run with a fake newer version: exactly the six version strings across the three csproj files changed, nothing else.
- Workflow YAML parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)