### PR TITLE
Handle Android banner lifecycle more safely

### DIFF
--- a/src/Plugin.AdMob/Config.cs
+++ b/src/Plugin.AdMob/Config.cs
@@ -91,17 +91,33 @@ public static class Config
         builder.Services.AddSingleton<IAdConsentService>(adConsentService);
 
 #if ANDROID || IOS
+#if ANDROID
+        builder.ConfigureLifecycleEvents(events =>
+        {
+            events.AddAndroid(android =>
+            {
+                // Banner handlers manage native AdView instances, so they need
+                // explicit pause/resume hooks when the app moves through Android lifecycle.
+                var lifecycle = android
+                    .OnResume(_ => BannerAdHandler.ResumeActiveBanners())
+                    .OnPause(_ => BannerAdHandler.PauseActiveBanners())
+                    .OnStop(_ => BannerAdHandler.PauseActiveBanners());
+
+                if (automaticallyAskForConsent is true)
+                {
+                    lifecycle.OnStart(_ => OnStart());
+                }
+            });
+        });
+#elif IOS
         if (automaticallyAskForConsent is true)
         {
             builder.ConfigureLifecycleEvents(events =>
             {
-#if ANDROID
-                events.AddAndroid(android => android.OnStart(_ => OnStart()));
-#elif IOS
                 events.AddiOS(ios => ios.OnActivated(_ => OnStart()));
-#endif
             });
         }
+#endif
 
         void OnStart()
         {

--- a/src/Plugin.AdMob/Platforms/Android/Banner/BannerAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/Android/Banner/BannerAdHandler.cs
@@ -4,11 +4,17 @@ using Microsoft.Maui.Handlers;
 using Plugin.AdMob.Configuration;
 using Plugin.AdMob.Platforms.Android;
 using Plugin.AdMob.Services;
+using System.Collections.Generic;
 
 namespace Plugin.AdMob.Handlers;
 
 internal partial class BannerAdHandler : ViewHandler<BannerAd, AdView>
 {
+    // Active banner views are tracked so app lifecycle can pause/resume them
+    // without forcing the host app to recreate the MAUI control.
+    private static readonly object _activeViewsLock = new();
+    private static readonly List<WeakReference<AdView>> _activeViews = [];
+
     private IAdConsentService? _adConsentService;
     private EventHandler<IConsentInformation?>? _consentInfoUpdatedHandler;
 
@@ -17,6 +23,34 @@ internal partial class BannerAdHandler : ViewHandler<BannerAd, AdView>
 
     public BannerAdHandler() : base(PropertyMapper) { }
 
+    internal static void PauseActiveBanners()
+    {
+        foreach (var adView in GetActiveViews())
+        {
+            try
+            {
+                adView.Pause();
+            }
+            catch (Exception)
+            {
+            }
+        }
+    }
+
+    internal static void ResumeActiveBanners()
+    {
+        foreach (var adView in GetActiveViews())
+        {
+            try
+            {
+                adView.Resume();
+            }
+            catch (Exception)
+            {
+            }
+        }
+    }
+
     protected override void DisconnectHandler(AdView platformView)
     {
         if (_adConsentService is not null)
@@ -24,6 +58,12 @@ internal partial class BannerAdHandler : ViewHandler<BannerAd, AdView>
             _adConsentService.OnConsentInfoUpdated -= OnConsentInfoUpdated;
         }
 
+        RemoveActiveView(platformView);
+        // Explicitly stop the native AdView before disposal so Android does not
+        // keep banner work alive after the handler has been disconnected.
+        platformView.AdListener = null;
+        platformView.Pause();
+        platformView.Destroy();
         platformView.Dispose();
         base.DisconnectHandler(platformView);
     }
@@ -69,6 +109,7 @@ internal partial class BannerAdHandler : ViewHandler<BannerAd, AdView>
             VirtualView.WidthRequest = 0;
         }
 
+        AddActiveView(adView);
         return adView;
     }
 
@@ -179,5 +220,50 @@ internal partial class BannerAdHandler : ViewHandler<BannerAd, AdView>
             // Handler has been disconnected, ignore ad event.
             // This prevents: System.InvalidOperationException: VirtualView cannot be null here
         }
+    }
+
+    private static void AddActiveView(AdView adView)
+    {
+        lock (_activeViewsLock)
+        {
+            _activeViews.Add(new WeakReference<AdView>(adView));
+        }
+    }
+
+    private static void RemoveActiveView(AdView adView)
+    {
+        lock (_activeViewsLock)
+        {
+            _activeViews.RemoveAll(reference =>
+            {
+                if (!reference.TryGetTarget(out var target))
+                {
+                    return true;
+                }
+
+                return ReferenceEquals(target, adView);
+            });
+        }
+    }
+
+    private static List<AdView> GetActiveViews()
+    {
+        List<AdView> activeViews = [];
+
+        lock (_activeViewsLock)
+        {
+            _activeViews.RemoveAll(reference =>
+            {
+                if (!reference.TryGetTarget(out var target))
+                {
+                    return true;
+                }
+
+                activeViews.Add(target);
+                return false;
+            });
+        }
+
+        return activeViews;
     }
 }

--- a/src/Plugin.AdMob/Platforms/Android/Banner/BannerAdHandler.cs
+++ b/src/Plugin.AdMob/Platforms/Android/Banner/BannerAdHandler.cs
@@ -33,6 +33,7 @@ internal partial class BannerAdHandler : ViewHandler<BannerAd, AdView>
             }
             catch (Exception)
             {
+                RemoveActiveView(adView);
             }
         }
     }
@@ -47,6 +48,7 @@ internal partial class BannerAdHandler : ViewHandler<BannerAd, AdView>
             }
             catch (Exception)
             {
+                RemoveActiveView(adView);
             }
         }
     }
@@ -58,14 +60,23 @@ internal partial class BannerAdHandler : ViewHandler<BannerAd, AdView>
             _adConsentService.OnConsentInfoUpdated -= OnConsentInfoUpdated;
         }
 
-        RemoveActiveView(platformView);
-        // Explicitly stop the native AdView before disposal so Android does not
-        // keep banner work alive after the handler has been disconnected.
-        platformView.AdListener = null;
-        platformView.Pause();
-        platformView.Destroy();
-        platformView.Dispose();
-        base.DisconnectHandler(platformView);
+        try
+        {
+            RemoveActiveView(platformView);
+            // Explicitly stop the native AdView before disposal so Android does not
+            // keep banner work alive after the handler has been disconnected.
+            platformView.AdListener = null;
+            platformView.Pause();
+            platformView.Destroy();
+            platformView.Dispose();
+        }
+        catch (Exception)
+        {
+        }
+        finally
+        {
+            base.DisconnectHandler(platformView);
+        }
     }
 
     protected override AdView CreatePlatformView()


### PR DESCRIPTION
## Summary

Improve Android banner lifecycle handling for `BannerAd`.

## Changes

- track active `AdView` instances
- pause banners on app pause/stop
- resume banners on app resume
- clear listeners before disconnect/destroy
- remove disconnected views from the active list

## Motivation

This makes banner cleanup and lifecycle transitions more defensive on Android, especially when pages are destroyed or the app moves between foreground and background.