### PR TITLE
Bump Microsoft.Extensions.Logging.Debug to 10.0.10 in samples

### DIFF
--- a/samples/Foo.Bar.SampleApp.Hybrid/Foo.Bar.SampleApp.Hybrid.csproj
+++ b/samples/Foo.Bar.SampleApp.Hybrid/Foo.Bar.SampleApp.Hybrid.csproj
@@ -54,7 +54,7 @@
         <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.90" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.90" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="10.0.90" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
     </ItemGroup>
 
     <!-- Aligns the AndroidX Ktx packages with the resolved base package versions to silence NU1608 warnings. See: https://github.com/marius-bughiu/Plugin.AdMob/issues/82 -->

--- a/samples/Foo.Bar.SampleApp/Foo.Bar.SampleApp.csproj
+++ b/samples/Foo.Bar.SampleApp/Foo.Bar.SampleApp.csproj
@@ -52,7 +52,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.90" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.90" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.10" />
 	</ItemGroup>
 
 	<!-- Aligns the AndroidX Ktx packages with the resolved base package versions to silence NU1608 warnings. See: https://github.com/marius-bughiu/Plugin.AdMob/issues/82 -->


### PR DESCRIPTION
## What

Bumps `Microsoft.Extensions.Logging.Debug` from **10.0.9 → 10.0.10** in both sample apps:

- `samples/Foo.Bar.SampleApp/Foo.Bar.SampleApp.csproj`
- `samples/Foo.Bar.SampleApp.Hybrid/Foo.Bar.SampleApp.Hybrid.csproj`

## Why

Routine dependency check. Every dependency in the published plugin (`src/Plugin.AdMob`) is already at its latest stable release — the ad SDKs (`Xamarin.GooglePlayServices.Ads.Lite` 124.0.0.8, `Jc.GMA.iOS` 12.10.0, `Jc.UMP.iOS` 2.7.5), MAUI 10.0.90 (11.0 is preview-only), and MinVer 7.0.0 (8.0.0 is alpha/rc-only). This patch bump on the samples' debug-logging package was the only available update.

## Notes for reviewers

- **No change to the published NuGet package** — this dependency lives only in the sample apps.
- The AndroidX `*.Ktx` packages in the samples are intentionally left as-is; they're pinned to align with what MAUI 10.0.90 resolves (silencing NU1608, per #82) and are already at their latest versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)