### PR TITLE
Add CI gates: PR build, nightly published-package tests, validated MAUI bump

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts run on Linux CI runners — CRLF would break the shebang.
+*.sh text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,18 +33,22 @@ jobs:
           # not just the library — and an Android app build needs no code signing.
           - os: ubuntu-latest
             tfm: net10.0-android
+            workload: maui-android
             project: samples/Foo.Bar.SampleApp/Foo.Bar.SampleApp.csproj
           # iOS / MacCatalyst / Windows compile the plugin library (same as release.yml). App-level
           # iOS link is covered advisorily by device-tests.yml; keeping it out of the hard gate
           # avoids iOS app signing/link flaking the gate for non-code reasons.
           - os: macos-latest
             tfm: net10.0-ios
+            workload: maui-ios
             project: src/Plugin.AdMob/Plugin.AdMob.csproj
           - os: macos-latest
             tfm: net10.0-maccatalyst
+            workload: maui-maccatalyst
             project: src/Plugin.AdMob/Plugin.AdMob.csproj
           - os: windows-latest
             tfm: net10.0-windows10.0.19041.0
+            workload: maui-windows
             project: src/Plugin.AdMob/Plugin.AdMob.csproj
 
     steps:
@@ -56,13 +60,22 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      # Install the leg's workload explicitly rather than `dotnet workload restore <project>`:
+      # that has to evaluate the project first, and on a clean runner the platform TFMs aren't
+      # known yet, so a MAUI app degrades to plain net10.0 and can't reference the
+      # platform-targeted plugin ("It cannot be referenced by a project that targets
+      # '.NETCoreApp,Version=v10.0'").
       - name: Install MAUI workload
-        run: dotnet workload restore ${{ matrix.project }}
+        run: dotnet workload install ${{ matrix.workload }}
 
+      # -p:TargetFrameworks (not -f): `-f` still leaves restore cross-targeting, which would
+      # demand every platform's workload on every leg. Setting the property as a global
+      # property narrows restore, and propagates through the ProjectReference so the plugin
+      # is restored for this TFM only.
       - name: Build (${{ matrix.tfm }})
         shell: pwsh
         run: |
-          dotnet build ${{ matrix.project }} -f ${{ matrix.tfm }} -warnaserror:NU1605 --nologo | Tee-Object -FilePath build.log
+          dotnet build ${{ matrix.project }} -p:TargetFrameworks=${{ matrix.tfm }} -warnaserror:NU1605 --nologo | Tee-Object -FilePath build.log
           exit $LASTEXITCODE
 
       - name: Surface NU1608 native binding drift

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,83 @@
+name: Build
+
+# Source-build gate. Restores + compiles the plugin and the sample app across every
+# platform it ships, on every PR and push to main. Hard-fails on NU1605 (package
+# downgrade) and surfaces NU1608 (native binding constraint drift, the issue #68 / #82
+# class) to the run summary. Also callable (workflow_call) so the MAUI auto-bump can
+# validate its own change before opening a PR.
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to check out and build.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: ${{ matrix.tfm }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Android builds the sample APP, so the manifest merge (issue #68) is exercised,
+          # not just the library — and an Android app build needs no code signing.
+          - os: ubuntu-latest
+            tfm: net10.0-android
+            project: samples/Foo.Bar.SampleApp/Foo.Bar.SampleApp.csproj
+          # iOS / MacCatalyst / Windows compile the plugin library (same as release.yml). App-level
+          # iOS link is covered advisorily by device-tests.yml; keeping it out of the hard gate
+          # avoids iOS app signing/link flaking the gate for non-code reasons.
+          - os: macos-latest
+            tfm: net10.0-ios
+            project: src/Plugin.AdMob/Plugin.AdMob.csproj
+          - os: macos-latest
+            tfm: net10.0-maccatalyst
+            project: src/Plugin.AdMob/Plugin.AdMob.csproj
+          - os: windows-latest
+            tfm: net10.0-windows10.0.19041.0
+            project: src/Plugin.AdMob/Plugin.AdMob.csproj
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install MAUI workload
+        run: dotnet workload restore ${{ matrix.project }}
+
+      - name: Build (${{ matrix.tfm }})
+        shell: pwsh
+        run: |
+          dotnet build ${{ matrix.project }} -f ${{ matrix.tfm }} -warnaserror:NU1605 --nologo | Tee-Object -FilePath build.log
+          exit $LASTEXITCODE
+
+      - name: Surface NU1608 native binding drift
+        if: always()
+        shell: pwsh
+        run: |
+          if (Test-Path build.log) {
+            $nu = Select-String -Path build.log -Pattern 'warning NU1608' |
+                  ForEach-Object { ($_.Line -replace '.*warning NU1608', 'NU1608').Trim() } |
+                  Sort-Object -Unique
+            if ($nu) {
+              "### NU1608 dependency-constraint conflicts — ${{ matrix.tfm }}" | Out-File $env:GITHUB_STEP_SUMMARY -Append
+              "These are transitive native-binding version skews. New entries (vs. previous runs) indicate upstream drift worth investigating." | Out-File $env:GITHUB_STEP_SUMMARY -Append
+              '```' | Out-File $env:GITHUB_STEP_SUMMARY -Append
+              $nu | Out-File $env:GITHUB_STEP_SUMMARY -Append
+              '```' | Out-File $env:GITHUB_STEP_SUMMARY -Append
+            }
+          }

--- a/.github/workflows/bump-maui.yml
+++ b/.github/workflows/bump-maui.yml
@@ -1,5 +1,10 @@
 name: Bump MAUI
 
+# Nightly check for a newer MAUI patch. Unlike before, the bump is now VALIDATED before a PR
+# is opened: the change is pushed to a branch, built across all target frameworks, and run
+# through the device tests. The PR is only opened when the build gate passes, so a MAUI patch
+# that fails to restore/compile against the native bindings never reaches review as a green PR.
+
 on:
   schedule:
     - cron: '0 6 * * *'
@@ -12,13 +17,16 @@ permissions:
 concurrency:
   group: bump-maui
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
-  bump:
+  check:
     runs-on: ubuntu-latest
+    outputs:
+      bump: ${{ steps.check.outputs.bump }}
+      current: ${{ steps.check.outputs.current }}
+      latest: ${{ steps.check.outputs.latest }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
 
@@ -44,10 +52,23 @@ jobs:
             echo "MAUI $current is up to date"
           fi
 
-      - name: Apply the version bump
-        if: steps.check.outputs.bump == 'true'
+  prepare:
+    needs: check
+    if: needs.check.outputs.bump == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      # The candidate goes to a THROWAWAY branch, never straight to the reviewed branch. The
+      # reviewed branch is only moved once the gate is green (see open-pr), so a failing bump
+      # can't silently replace the head of an already-open, already-validated PR.
+      - name: Apply the version bump and push a validation branch
+        id: push
         env:
-          LATEST: ${{ steps.check.outputs.latest }}
+          LATEST: ${{ needs.check.outputs.latest }}
         run: |
           sed -i -E "s|<MauiPackageVersion>[^<]+</MauiPackageVersion>|<MauiPackageVersion>$LATEST</MauiPackageVersion>|" \
             src/Plugin.AdMob/Plugin.AdMob.csproj
@@ -58,18 +79,107 @@ jobs:
             samples/Foo.Bar.SampleApp/Foo.Bar.SampleApp.csproj \
             samples/Foo.Bar.SampleApp.Hybrid/Foo.Bar.SampleApp.Hybrid.csproj
           git diff --stat
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B bump-maui-validate
+          git commit -am "Bump .NET MAUI to $LATEST"
+          git push --force origin bump-maui-validate
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Open pull request
-        if: steps.check.outputs.bump == 'true'
-        uses: peter-evans/create-pull-request@v7
+  # Hard gate: the bumped source must restore + compile on every target framework.
+  validate-build:
+    needs: [check, prepare]
+    if: needs.check.outputs.bump == 'true'
+    uses: ./.github/workflows/build.yml
+    with:
+      ref: bump-maui-validate
+
+  # Runtime signal: device tests against the bumped SOURCE. Advisory for opening the PR
+  # (its result is reported in the PR body) so emulator flakiness can't block a valid bump.
+  validate-device:
+    needs: [check, prepare]
+    if: needs.check.outputs.bump == 'true'
+    uses: ./.github/workflows/device-tests.yml
+    with:
+      ref: bump-maui-validate
+      use_published: false
+      # Pin MAUI to the version being bumped to — otherwise the harness's floating
+      # Microsoft.Maui.Controls reference would test a different MAUI than the PR ships.
+      maui_version: ${{ needs.check.outputs.latest }}
+
+  open-pr:
+    needs: [check, prepare, validate-build, validate-device]
+    if: always() && needs.check.outputs.bump == 'true' && needs.validate-build.result == 'success'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
         with:
-          branch: bump-maui-version
-          delete-branch: true
-          commit-message: Bump .NET MAUI to ${{ steps.check.outputs.latest }}
-          title: Bump .NET MAUI to ${{ steps.check.outputs.latest }}
-          body: |
-            Bumps .NET MAUI from `${{ steps.check.outputs.current }}` to `${{ steps.check.outputs.latest }}`.
+          ref: bump-maui-validate
+          fetch-depth: 0   # need real history to tell bot commits from human ones
 
-            Updates `MauiPackageVersion` in the plugin (which also becomes the next plugin package version) and the pinned MAUI packages in both sample apps.
+      # Move the reviewed branch onto the validated commit. Head, title and body therefore
+      # always change together — the atomicity peter-evans/create-pull-request used to give us.
+      - name: Promote the validated commit onto the review branch
+        id: promote
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git fetch --no-tags origin +refs/heads/bump-maui-version:refs/remotes/origin/bump-maui-version || true
 
-            Release notes: https://github.com/dotnet/maui/releases
+          if ! git rev-parse -q --verify refs/remotes/origin/bump-maui-version >/dev/null; then
+            git push origin HEAD:refs/heads/bump-maui-version
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Already holds exactly this change (open PR, re-run on a later night): leave it alone.
+          if [ "$(git rev-parse refs/remotes/origin/bump-maui-version^{tree})" = "$(git rev-parse HEAD^{tree})" ]; then
+            echo "bump-maui-version already holds this exact change; nothing to push."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Only inspect commits unique to the branch, so main's own human history is ignored.
+          if git log --format=%ae refs/remotes/origin/main..refs/remotes/origin/bump-maui-version |
+             grep -qv '^41898282+github-actions\[bot\]@users\.noreply\.github\.com$'; then
+            echo "::warning::bump-maui-version carries manual commits — skipping the bump rather than clobbering them."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git push --force-with-lease=bump-maui-version:"$(git rev-parse refs/remotes/origin/bump-maui-version)" \
+            origin HEAD:refs/heads/bump-maui-version
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the pull request
+        if: steps.promote.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT: ${{ needs.check.outputs.current }}
+          LATEST: ${{ needs.check.outputs.latest }}
+          BUILD_RESULT: ${{ needs.validate-build.result }}
+          DEVICE_RESULT: ${{ needs.validate-device.result }}
+        run: |
+          body=$(printf '%s\n' \
+            "Bumps .NET MAUI from \`$CURRENT\` to \`$LATEST\`." \
+            "" \
+            "Updates \`MauiPackageVersion\` in the plugin (which also becomes the next plugin package version) and the pinned MAUI packages in both sample apps." \
+            "" \
+            "**Pre-merge validation on this exact commit:**" \
+            "- Build gate (all target frameworks): $BUILD_RESULT" \
+            "- Device tests (Android emulator, banner hard-gate): $DEVICE_RESULT" \
+            "" \
+            "Release notes: https://github.com/dotnet/maui/releases")
+          existing=$(gh pr list --head bump-maui-version --state open --json number -q '.[0].number' || true)
+          if [ -n "$existing" ]; then
+            echo "PR #$existing already open; branch push updated it."
+            gh pr edit "$existing" --title "Bump .NET MAUI to $LATEST" --body "$body"
+          else
+            gh pr create --base main --head bump-maui-version --title "Bump .NET MAUI to $LATEST" --body "$body"
+          fi
+
+      - name: Clean up the validation branch
+        if: always()
+        run: git push origin --delete bump-maui-validate || true

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -1,0 +1,167 @@
+name: Device tests
+
+# Runs the on-device ad-load harness (tests/Plugin.AdMob.DeviceTests) on an Android emulator
+# and, best-effort, an iOS simulator. Each format is loaded with Google's test ad units and we
+# assert OnAdLoaded fires. Reusable (workflow_call) so both the nightly job (published package)
+# and the MAUI auto-bump gate (source) can invoke it.
+#
+# GATING MODEL — banner is the hard gate. On a headless, software-GPU emulator (all GitHub-hosted
+# runners) only the banner format reliably fills; full-screen / native creatives need a GPU-backed
+# emulator (-gpu host) to pre-render, so they are advisory here. Set require_all_formats: true only
+# when pointing this at a GPU-capable / self-hosted runner.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+      use_published:
+        description: Reference the published NuGet package instead of the source.
+        required: false
+        type: boolean
+        default: false
+      admob_version:
+        required: false
+        type: string
+        default: ''
+      maui_version:
+        required: false
+        type: string
+        default: ''
+      require_all_formats:
+        description: Hard-fail unless every format loads (only meaningful on a -gpu host runner).
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      use_published:
+        description: Reference the published NuGet package instead of the source.
+        type: boolean
+        default: true
+      admob_version:
+        description: Package version to test (blank = latest).
+        type: string
+        default: ''
+      maui_version:
+        description: MAUI version to pin (blank = float).
+        type: string
+        default: ''
+      require_all_formats:
+        description: Hard-fail unless every format loads.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  android:
+    name: android emulator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      # `workload restore` (not `workload install maui-android`): the harness multi-targets
+      # android+ios and NuGet restore stays cross-targeting even under `-f net10.0-android`,
+      # so a missing iOS workload aborts the restore with NETSDK1147 before any APK is built.
+      - name: Install MAUI workloads
+        run: dotnet workload restore tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj
+
+      - name: Build test APK
+        run: |
+          props=""
+          if [ "${{ inputs.use_published }}" = "true" ]; then props="-p:UsePublishedAdMob=true"; fi
+          if [ -n "${{ inputs.admob_version }}" ]; then props="$props -p:AdMobPackageVersion=${{ inputs.admob_version }}"; fi
+          if [ -n "${{ inputs.maui_version }}" ]; then props="$props -p:MauiVersion=${{ inputs.maui_version }}"; fi
+          echo "Build props: $props"
+          dotnet build tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj -c Debug -f net10.0-android $props
+          apk=$(find "$PWD/tests/Plugin.AdMob.DeviceTests/bin" -name '*-Signed.apk' | head -1)
+          if [ -z "$apk" ]; then apk=$(find "$PWD/tests/Plugin.AdMob.DeviceTests/bin" -name '*.apk' | head -1); fi
+          if [ -z "$apk" ]; then echo "::error::No APK produced"; exit 1; fi
+          echo "APK=$apk" >> "$GITHUB_ENV"
+          echo "REQUIRE_ALL=${{ inputs.require_all_formats }}" >> "$GITHUB_ENV"
+          echo "Built $apk"
+
+      - name: Run harness on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          target: google_apis
+          force-avd-creation: false
+          disable-animations: true
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot
+          script: bash tests/ci/run-android-harness.sh
+
+  ios:
+    name: ios simulator (advisory)
+    runs-on: macos-latest
+    continue-on-error: true   # iOS full-screen fill is flaky headless; never block a gate on it.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      # Same cross-targeting restore constraint as the Android job — see the note there.
+      - name: Install MAUI workloads
+        run: dotnet workload restore tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj
+
+      - name: Build for the simulator
+        run: |
+          props=""
+          if [ "${{ inputs.use_published }}" = "true" ]; then props="-p:UsePublishedAdMob=true"; fi
+          if [ -n "${{ inputs.admob_version }}" ]; then props="$props -p:AdMobPackageVersion=${{ inputs.admob_version }}"; fi
+          if [ -n "${{ inputs.maui_version }}" ]; then props="$props -p:MauiVersion=${{ inputs.maui_version }}"; fi
+          dotnet build tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj -c Debug -f net10.0-ios -p:RuntimeIdentifier=iossimulator-arm64 $props
+          app=$(find tests/Plugin.AdMob.DeviceTests/bin -name '*.app' -type d | head -1)
+          echo "APP=$app" >> "$GITHUB_ENV"
+          echo "Built $app"
+
+      - name: Boot simulator, launch, scrape console
+        run: |
+          set -euo pipefail
+          device=$(xcrun simctl list devices available | grep -Eo 'iPhone 1[0-9][^(]*' | head -1 | xargs)
+          echo "Using simulator: $device"
+          xcrun simctl create harness-sim "$device" >/dev/null || true
+          udid=$(xcrun simctl list devices | grep harness-sim | grep -Eo '[0-9A-Fa-f-]{36}' | head -1)
+          # `boot` returns as soon as the boot is *initiated*; bootstatus -b boots if needed and
+          # blocks until the device is actually usable. install/launch both gate on device state.
+          xcrun simctl bootstatus "$udid" -b
+          xcrun simctl install "$udid" "$APP"
+          # Redirect rather than pipe: for a backgrounded pipeline $! is tee, so the later kill
+          # would tear down the log reader and leave the app running.
+          xcrun simctl launch --console-pty "$udid" com.plugin.admob.devicetests > sim.log 2>&1 &
+          launch_pid=$!
+          for _ in $(seq 1 96); do
+            if grep -qF "SUMMARY_ALL" sim.log 2>/dev/null; then break; fi
+            sleep 5
+          done
+          kill "$launch_pid" 2>/dev/null || true
+          echo "===== harness log ====="; grep "AdMobHarness:" sim.log || true; echo "======================="
+          # Distinguish "app never started" (a real, actionable failure) from "banner did not
+          # fill" (expected headless no-fill). The job stays continue-on-error, so this cannot
+          # block a caller — it just makes the advisory lane's red/green mean something.
+          if ! grep -qF "AdMobHarness:" sim.log; then
+            echo "::error::iOS harness produced no output — the app never started."
+            sed -n '1,40p' sim.log || true
+            exit 1
+          fi
+          grep -F "SUMMARY_BANNER" sim.log | tail -1 || echo "(no banner summary — iOS advisory)"

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -75,11 +75,8 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      # `workload restore` (not `workload install maui-android`): the harness multi-targets
-      # android+ios and NuGet restore stays cross-targeting even under `-f net10.0-android`,
-      # so a missing iOS workload aborts the restore with NETSDK1147 before any APK is built.
-      - name: Install MAUI workloads
-        run: dotnet workload restore tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj
+      - name: Install MAUI Android workload
+        run: dotnet workload install maui-android
 
       - name: Build test APK
         run: |
@@ -88,7 +85,9 @@ jobs:
           if [ -n "${{ inputs.admob_version }}" ]; then props="$props -p:AdMobPackageVersion=${{ inputs.admob_version }}"; fi
           if [ -n "${{ inputs.maui_version }}" ]; then props="$props -p:MauiVersion=${{ inputs.maui_version }}"; fi
           echo "Build props: $props"
-          dotnet build tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj -c Debug -f net10.0-android $props
+          # -p:TargetFrameworks (not -f) so restore is single-TFM: `-f` leaves restore
+          # cross-targeting, which would fail with NETSDK1147 for the iOS TFM on this runner.
+          dotnet build tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj -c Debug -p:TargetFrameworks=net10.0-android $props
           apk=$(find "$PWD/tests/Plugin.AdMob.DeviceTests/bin" -name '*-Signed.apk' | head -1)
           if [ -z "$apk" ]; then apk=$(find "$PWD/tests/Plugin.AdMob.DeviceTests/bin" -name '*.apk' | head -1); fi
           if [ -z "$apk" ]; then echo "::error::No APK produced"; exit 1; fi
@@ -120,9 +119,8 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      # Same cross-targeting restore constraint as the Android job — see the note there.
-      - name: Install MAUI workloads
-        run: dotnet workload restore tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj
+      - name: Install MAUI iOS workload
+        run: dotnet workload install maui-ios
 
       - name: Build for the simulator
         run: |
@@ -130,7 +128,7 @@ jobs:
           if [ "${{ inputs.use_published }}" = "true" ]; then props="-p:UsePublishedAdMob=true"; fi
           if [ -n "${{ inputs.admob_version }}" ]; then props="$props -p:AdMobPackageVersion=${{ inputs.admob_version }}"; fi
           if [ -n "${{ inputs.maui_version }}" ]; then props="$props -p:MauiVersion=${{ inputs.maui_version }}"; fi
-          dotnet build tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj -c Debug -f net10.0-ios -p:RuntimeIdentifier=iossimulator-arm64 $props
+          dotnet build tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj -c Debug -p:TargetFrameworks=net10.0-ios -p:RuntimeIdentifier=iossimulator-arm64 $props
           app=$(find tests/Plugin.AdMob.DeviceTests/bin -name '*.app' -type d | head -1)
           echo "APP=$app" >> "$GITHUB_ENV"
           echo "Built $app"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,12 +41,16 @@ jobs:
         include:
           - os: ubuntu-latest
             tfm: net10.0-android
+            workload: maui-android
           - os: macos-latest
             tfm: net10.0-ios
+            workload: maui-ios
           - os: macos-latest
             tfm: net10.0-maccatalyst
+            workload: maui-maccatalyst
           - os: windows-latest
             tfm: net10.0-windows10.0.19041.0
+            workload: maui-windows
     steps:
       - uses: actions/checkout@v4
 
@@ -54,8 +58,10 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      # Explicit install + -p:TargetFrameworks below, so restore stays single-TFM and this
+      # leg only needs its own workload. See the note in build.yml.
       - name: Install MAUI workload
-        run: dotnet workload restore tests/Plugin.AdMob.PackageConsumer/Plugin.AdMob.PackageConsumer.csproj
+        run: dotnet workload install ${{ matrix.workload }}
 
       - name: Clear NuGet cache (force today's published package)
         run: dotnet nuget locals all --clear
@@ -64,7 +70,7 @@ jobs:
         shell: pwsh
         run: |
           dotnet build tests/Plugin.AdMob.PackageConsumer/Plugin.AdMob.PackageConsumer.csproj `
-            -f ${{ matrix.tfm }} `
+            -p:TargetFrameworks=${{ matrix.tfm }} `
             -p:AdMobPackageVersion=${{ needs.resolve.outputs.version }} `
             -p:MauiVersion=${{ needs.resolve.outputs.maui }} `
             -warnaserror:NU1605 --nologo | Tee-Object -FilePath build.log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,96 @@
+name: Nightly (published package)
+
+# Exercises the LATEST PUBLISHED Plugin.AdMob package (not the source) to catch upstream /
+# time-driven drift under a shipped release: new transitive native-binding versions, a MAUI
+# release that breaks restore, or Google SDK behavior changes. Runs before the MAUI auto-bump.
+
+on:
+  schedule:
+    - cron: '0 4 * * *'   # 04:00 UTC, ahead of bump-maui (06:00 UTC)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: resolve latest published version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      maui: ${{ steps.v.outputs.maui }}
+    steps:
+      - id: v
+        run: |
+          latest=$(curl -sf https://api.nuget.org/v3-flatcontainer/plugin.admob/index.json \
+            | jq -r '.versions[] | select(contains("-") | not)' | sort -V | tail -1)
+          if [ -z "$latest" ]; then echo "::error::Could not resolve latest published Plugin.AdMob version"; exit 1; fi
+          # The plugin version tracks MAUI: X.Y.Z[.build] -> MAUI X.Y.Z.
+          maui=$(echo "$latest" | awk -F. '{print $1"."$2"."$3}')
+          echo "version=$latest" >> "$GITHUB_OUTPUT"
+          echo "maui=$maui" >> "$GITHUB_OUTPUT"
+          echo "Latest published Plugin.AdMob: $latest (MAUI floor $maui)"
+
+  smoke:
+    name: build smoke ${{ matrix.tfm }}
+    needs: resolve
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            tfm: net10.0-android
+          - os: macos-latest
+            tfm: net10.0-ios
+          - os: macos-latest
+            tfm: net10.0-maccatalyst
+          - os: windows-latest
+            tfm: net10.0-windows10.0.19041.0
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install MAUI workload
+        run: dotnet workload restore tests/Plugin.AdMob.PackageConsumer/Plugin.AdMob.PackageConsumer.csproj
+
+      - name: Clear NuGet cache (force today's published package)
+        run: dotnet nuget locals all --clear
+
+      - name: Build against published ${{ needs.resolve.outputs.version }}
+        shell: pwsh
+        run: |
+          dotnet build tests/Plugin.AdMob.PackageConsumer/Plugin.AdMob.PackageConsumer.csproj `
+            -f ${{ matrix.tfm }} `
+            -p:AdMobPackageVersion=${{ needs.resolve.outputs.version }} `
+            -p:MauiVersion=${{ needs.resolve.outputs.maui }} `
+            -warnaserror:NU1605 --nologo | Tee-Object -FilePath build.log
+          exit $LASTEXITCODE
+
+      - name: Surface NU1608 native binding drift
+        if: always()
+        shell: pwsh
+        run: |
+          if (Test-Path build.log) {
+            $nu = Select-String -Path build.log -Pattern 'warning NU1608' |
+                  ForEach-Object { ($_.Line -replace '.*warning NU1608', 'NU1608').Trim() } |
+                  Sort-Object -Unique
+            if ($nu) {
+              "### NU1608 dependency-constraint conflicts — ${{ matrix.tfm }}" | Out-File $env:GITHUB_STEP_SUMMARY -Append
+              '```' | Out-File $env:GITHUB_STEP_SUMMARY -Append
+              $nu | Out-File $env:GITHUB_STEP_SUMMARY -Append
+              '```' | Out-File $env:GITHUB_STEP_SUMMARY -Append
+            }
+          }
+
+  device-tests:
+    name: device tests
+    needs: resolve
+    uses: ./.github/workflows/device-tests.yml
+    with:
+      use_published: true
+      admob_version: ${{ needs.resolve.outputs.version }}
+      maui_version: ${{ needs.resolve.outputs.maui }}

--- a/tests/Plugin.AdMob.DeviceTests/AdLoadHarness.cs
+++ b/tests/Plugin.AdMob.DeviceTests/AdLoadHarness.cs
@@ -1,0 +1,187 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.ApplicationModel;
+using Plugin.AdMob.Configuration;
+using Plugin.AdMob.Services;
+
+namespace Plugin.AdMob.DeviceTests;
+
+/// <summary>
+/// Drives a load of every ad format using Google's test ad units and reports whether each
+/// fired its OnAdLoaded callback. Asserting on LOAD (a network + SDK callback) rather than
+/// on-screen rendering is what makes this a stable signal for catching upstream binding /
+/// MAUI drift in the published package.
+///
+/// Environment note baked in from the maintainer's own testing: on a headless, software-GPU
+/// emulator (GitHub-hosted runners have no GPU) only the BANNER format reliably fills. The
+/// full-screen and native formats need a GPU-backed emulator (-gpu host) to pre-render their
+/// creative and otherwise come back as no-fill. Hence two summary lines are emitted:
+///   SUMMARY_BANNER — the format CI can hard-gate on any runner.
+///   SUMMARY_ALL    — every format; only meaningful (hard-gate-able) on a -gpu host runner.
+/// </summary>
+internal static class AdLoadHarness
+{
+    private const int TimeoutSeconds = 30;
+    private const int Attempts = 2;
+
+    public static async Task RunAllAsync(Layout bannerHost)
+    {
+        HarnessLog.Line("START");
+
+        // Give the Mobile Ads SDK a moment to initialize before the first request.
+        await Task.Delay(TimeSpan.FromSeconds(3));
+
+        var services = IPlatformApplication.Current?.Services
+            ?? throw new InvalidOperationException("No MAUI service provider available.");
+
+        var interstitial = services.GetRequiredService<IInterstitialAdService>();
+        var rewarded = services.GetRequiredService<IRewardedAdService>();
+        var rewardedInterstitial = services.GetRequiredService<IRewardedInterstitialAdService>();
+        var appOpen = services.GetRequiredService<IAppOpenAdService>();
+        var native = services.GetRequiredService<INativeAdService>();
+
+        // Banner first — the one format that fills on a headless software-GPU emulator.
+        var banner = await RunBannerAsync(bannerHost);
+
+        var results = new List<bool>
+        {
+            banner,
+            await RunInterstitialAsync(interstitial.CreateAd()),
+            await RunRewardedAsync(rewarded.CreateAd()),
+            await RunRewardedInterstitialAsync(rewardedInterstitial.CreateAd()),
+            await RunAppOpenAsync(appOpen.CreateAd()),
+            await RunNativeAsync("native", native.CreateAd()),
+            await RunNativeAsync("native-video", native.CreateAd(null, new VideoOptions { StartMuted = true })),
+        };
+
+        var passed = results.Count(x => x);
+
+        HarnessLog.Line($"SUMMARY_BANNER status={(banner ? "PASS" : "FAIL")}");
+        HarnessLog.Line($"SUMMARY_ALL status={(passed == results.Count ? "PASS" : "FAIL")} passed={passed} total={results.Count}");
+    }
+
+    private static Task<bool> RunInterstitialAsync(IInterstitialAd ad) => AwaitLoadAsync(
+        "interstitial",
+        (l, f) => { ad.OnAdLoaded += l; ad.OnAdFailedToLoad += f; },
+        (l, f) => { ad.OnAdLoaded -= l; ad.OnAdFailedToLoad -= f; },
+        ad.Load);
+
+    private static Task<bool> RunRewardedAsync(IRewardedAd ad) => AwaitLoadAsync(
+        "rewarded",
+        (l, f) => { ad.OnAdLoaded += l; ad.OnAdFailedToLoad += f; },
+        (l, f) => { ad.OnAdLoaded -= l; ad.OnAdFailedToLoad -= f; },
+        ad.Load);
+
+    private static Task<bool> RunRewardedInterstitialAsync(IRewardedInterstitialAd ad) => AwaitLoadAsync(
+        "rewarded-interstitial",
+        (l, f) => { ad.OnAdLoaded += l; ad.OnAdFailedToLoad += f; },
+        (l, f) => { ad.OnAdLoaded -= l; ad.OnAdFailedToLoad -= f; },
+        ad.Load);
+
+    private static Task<bool> RunAppOpenAsync(IAppOpenAd ad) => AwaitLoadAsync(
+        "app-open",
+        (l, f) => { ad.OnAdLoaded += l; ad.OnAdFailedToLoad += f; },
+        (l, f) => { ad.OnAdLoaded -= l; ad.OnAdFailedToLoad -= f; },
+        ad.Load);
+
+    private static Task<bool> RunNativeAsync(string format, INativeAd ad) => AwaitLoadAsync(
+        format,
+        (l, f) => { ad.OnAdLoaded += l; ad.OnAdFailedToLoad += f; },
+        (l, f) => { ad.OnAdLoaded -= l; ad.OnAdFailedToLoad -= f; },
+        ad.Load);
+
+    /// <summary>
+    /// Subscribes to a format's load / fail events, triggers the load on the UI thread, and
+    /// waits (with a timeout and a retry) for the first callback. The subscribe/unsubscribe
+    /// lambdas capture the concrete ad instance so no shared base interface is needed.
+    /// </summary>
+    private static async Task<bool> AwaitLoadAsync(
+        string format,
+        Action<EventHandler, EventHandler<IAdError>> subscribe,
+        Action<EventHandler, EventHandler<IAdError>> unsubscribe,
+        Action load)
+    {
+        for (var attempt = 1; attempt <= Attempts; attempt++)
+        {
+            var tcs = new TaskCompletionSource<string?>(); // null message = loaded, otherwise the failure detail
+            EventHandler onLoaded = (_, _) => tcs.TrySetResult(null);
+            EventHandler<IAdError> onFailed = (_, e) => tcs.TrySetResult(e?.Message ?? "unknown error");
+
+            subscribe(onLoaded, onFailed);
+
+            try
+            {
+                await MainThread.InvokeOnMainThreadAsync(load);
+
+                var finished = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(TimeoutSeconds)));
+                var detail = finished == tcs.Task ? await tcs.Task : $"timeout after {TimeoutSeconds}s";
+
+                if (detail is null)
+                {
+                    HarnessLog.Line($"RESULT format={format} status=PASS attempt={attempt}");
+                    return true;
+                }
+
+                HarnessLog.Line($"RESULT format={format} status={LastOrRetry(attempt)} attempt={attempt} detail=\"{Sanitize(detail)}\"");
+            }
+            catch (Exception ex)
+            {
+                HarnessLog.Line($"RESULT format={format} status={LastOrRetry(attempt)} attempt={attempt} detail=\"{Sanitize(ex.Message)}\"");
+            }
+            finally
+            {
+                unsubscribe(onLoaded, onFailed);
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Banner has no Load()/CreateAd() API — its handler auto-loads when the control enters a
+    /// rendered visual tree, so each attempt uses a fresh control in a cleared host.
+    /// </summary>
+    private static async Task<bool> RunBannerAsync(Layout host)
+    {
+        for (var attempt = 1; attempt <= Attempts; attempt++)
+        {
+            var banner = new BannerAd { AdSize = AdSize.Banner };
+            var tcs = new TaskCompletionSource<string?>();
+            EventHandler onLoaded = (_, _) => tcs.TrySetResult(null);
+            EventHandler<IAdError> onFailed = (_, e) => tcs.TrySetResult(e?.Message ?? "unknown error");
+
+            banner.OnAdLoaded += onLoaded;
+            banner.OnAdFailedToLoad += onFailed;
+
+            try
+            {
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                {
+                    host.Clear();
+                    host.Add(banner);
+                });
+
+                var finished = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(TimeoutSeconds)));
+                var detail = finished == tcs.Task ? await tcs.Task : $"timeout after {TimeoutSeconds}s";
+
+                if (detail is null)
+                {
+                    HarnessLog.Line($"RESULT format=banner status=PASS attempt={attempt}");
+                    return true;
+                }
+
+                HarnessLog.Line($"RESULT format=banner status={LastOrRetry(attempt)} attempt={attempt} detail=\"{Sanitize(detail)}\"");
+            }
+            finally
+            {
+                banner.OnAdLoaded -= onLoaded;
+                banner.OnAdFailedToLoad -= onFailed;
+            }
+        }
+
+        return false;
+    }
+
+    private static string LastOrRetry(int attempt) => attempt < Attempts ? "RETRY" : "FAIL";
+
+    private static string Sanitize(string s) => s.Replace('\r', ' ').Replace('\n', ' ').Replace('"', '\'');
+}

--- a/tests/Plugin.AdMob.DeviceTests/App.cs
+++ b/tests/Plugin.AdMob.DeviceTests/App.cs
@@ -1,0 +1,7 @@
+namespace Plugin.AdMob.DeviceTests;
+
+public class App : Application
+{
+    protected override Window CreateWindow(IActivationState? activationState)
+        => new Window(new HarnessPage());
+}

--- a/tests/Plugin.AdMob.DeviceTests/HarnessLog.cs
+++ b/tests/Plugin.AdMob.DeviceTests/HarnessLog.cs
@@ -1,0 +1,19 @@
+namespace Plugin.AdMob.DeviceTests;
+
+/// <summary>
+/// Writes harness results to the platform log under a stable tag so CI can scrape them.
+/// The line CI keys off is: <c>SUMMARY status=PASS|FAIL passed=&lt;n&gt; total=&lt;m&gt;</c>.
+/// </summary>
+internal static class HarnessLog
+{
+    public const string Tag = "AdMobHarness";
+
+    public static void Line(string message)
+    {
+#if ANDROID
+        Android.Util.Log.Info(Tag, message);
+#else
+        Console.WriteLine($"{Tag}: {message}");
+#endif
+    }
+}

--- a/tests/Plugin.AdMob.DeviceTests/HarnessPage.cs
+++ b/tests/Plugin.AdMob.DeviceTests/HarnessPage.cs
@@ -1,0 +1,54 @@
+namespace Plugin.AdMob.DeviceTests;
+
+/// <summary>
+/// The app's only page. On first render it kicks off the ad-load harness; the banner
+/// format needs a live view in the tree, so the harness is handed this page's banner host.
+/// </summary>
+public class HarnessPage : ContentPage
+{
+    private readonly VerticalStackLayout _bannerHost = new();
+    private bool _started;
+
+    public HarnessPage()
+    {
+        Title = "AdMob Device Tests";
+        Content = new ScrollView
+        {
+            Content = new VerticalStackLayout
+            {
+                Padding = 16,
+                Spacing = 8,
+                Children =
+                {
+                    new Label { Text = "AdMob device test harness running…" },
+                    _bannerHost,
+                },
+            },
+        };
+
+        Loaded += OnLoaded;
+    }
+
+    private async void OnLoaded(object? sender, EventArgs e)
+    {
+        if (_started)
+        {
+            return;
+        }
+
+        _started = true;
+
+        try
+        {
+            await AdLoadHarness.RunAllAsync(_bannerHost);
+        }
+        catch (Exception ex)
+        {
+            // Emit the summary lines CI scrapes so a startup failure fails the run fast
+            // instead of waiting out the log-polling timeout.
+            HarnessLog.Line($"RESULT format=harness status=FAIL detail=\"{ex.Message.Replace('\n', ' ').Replace('\r', ' ').Replace('"', '\'')}\"");
+            HarnessLog.Line("SUMMARY_BANNER status=FAIL");
+            HarnessLog.Line("SUMMARY_ALL status=FAIL passed=0 total=0");
+        }
+    }
+}

--- a/tests/Plugin.AdMob.DeviceTests/MauiProgram.cs
+++ b/tests/Plugin.AdMob.DeviceTests/MauiProgram.cs
@@ -1,0 +1,25 @@
+using Microsoft.Maui.Hosting;
+using Plugin.AdMob.Configuration;
+
+namespace Plugin.AdMob.DeviceTests;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        // Route every request to Google's official test ad units — no AdMob account,
+        // no invalid-traffic risk, and Google guarantees these demo units fill.
+        AdConfig.UseTestAdUnitIds = true;
+
+        var builder = MauiApp.CreateBuilder();
+
+        builder
+            .UseMauiApp<App>()
+            // Headless run: bypass the UMP consent gate (a fresh app has no consent info,
+            // which would otherwise make every load early-return) and never surface a
+            // consent form.
+            .UseAdMob(disableConsentCheck: true, automaticallyAskForConsent: false);
+
+        return builder.Build();
+    }
+}

--- a/tests/Plugin.AdMob.DeviceTests/Platforms/Android/AndroidManifest.xml
+++ b/tests/Plugin.AdMob.DeviceTests/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true">
+		<activity android:name="com.google.android.gms.ads.AdActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize" android:theme="@android:style/Theme.Translucent" />
+		<!-- Google's sample AdMob app ID — matches the test ad units used by AdConfig.UseTestAdUnitIds. -->
+		<meta-data
+			android:name="com.google.android.gms.ads.APPLICATION_ID"
+			android:value="ca-app-pub-3940256099942544~3347511713" />
+	</application>
+	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	<uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/tests/Plugin.AdMob.DeviceTests/Platforms/Android/MainActivity.cs
+++ b/tests/Plugin.AdMob.DeviceTests/Platforms/Android/MainActivity.cs
@@ -1,0 +1,9 @@
+using Android.App;
+using Android.Content.PM;
+
+namespace Plugin.AdMob.DeviceTests;
+
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+public class MainActivity : MauiAppCompatActivity
+{
+}

--- a/tests/Plugin.AdMob.DeviceTests/Platforms/Android/MainApplication.cs
+++ b/tests/Plugin.AdMob.DeviceTests/Platforms/Android/MainApplication.cs
@@ -1,0 +1,15 @@
+using Android.App;
+using Android.Runtime;
+
+namespace Plugin.AdMob.DeviceTests;
+
+[Application]
+public class MainApplication : MauiApplication
+{
+    public MainApplication(IntPtr handle, JniHandleOwnership ownership)
+        : base(handle, ownership)
+    {
+    }
+
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/tests/Plugin.AdMob.DeviceTests/Platforms/iOS/AppDelegate.cs
+++ b/tests/Plugin.AdMob.DeviceTests/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,16 @@
+using Foundation;
+
+namespace Plugin.AdMob.DeviceTests;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp()
+    {
+        var app = MauiProgram.CreateMauiApp();
+
+        Google.MobileAds.MobileAds.SharedInstance.Start(completionHandler: null);
+
+        return app;
+    }
+}

--- a/tests/Plugin.AdMob.DeviceTests/Platforms/iOS/Info.plist
+++ b/tests/Plugin.AdMob.DeviceTests/Platforms/iOS/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>XSAppIconAssets</key>
+	<string>Assets.xcassets/appicon.appiconset</string>
+	<!-- Google's sample AdMob app ID — matches the test ad units used by AdConfig.UseTestAdUnitIds. -->
+	<key>GADApplicationIdentifier</key>
+	<string>ca-app-pub-3940256099942544~1458002511</string>
+	<key>GADIsAdManagerApp</key>
+	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+	</array>
+</dict>
+</plist>

--- a/tests/Plugin.AdMob.DeviceTests/Platforms/iOS/Program.cs
+++ b/tests/Plugin.AdMob.DeviceTests/Platforms/iOS/Program.cs
@@ -1,0 +1,13 @@
+using ObjCRuntime;
+using UIKit;
+
+namespace Plugin.AdMob.DeviceTests;
+
+public class Program
+{
+    // This is the main entry point of the application.
+    private static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj
+++ b/tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj
@@ -1,0 +1,87 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<!--
+		On-device integration test harness.
+
+		A minimal MAUI app that, on launch, asks the plugin to load every ad format
+		using Google's test ad units (AdConfig.UseTestAdUnitIds) and asserts each
+		OnAdLoaded fires. Results are written to the platform log with the tag
+		"AdMobHarness"; CI scrapes the SUMMARY line to pass/fail the job.
+
+		Reference mode is switchable:
+		  - default: ProjectReference to src/Plugin.AdMob (validates SOURCE, used by PR / bump gates).
+		  - -p:UsePublishedAdMob=true [-p:AdMobPackageVersion=x]: PackageReference to the
+		    PUBLISHED NuGet (validates the shipped artifact, used by the nightly job).
+
+		MAUI must be referenced explicitly (as of .NET 8 <UseMaui>true</UseMaui> no longer
+		injects Microsoft.Maui.Controls, and the SDK-bundled floor is older than the plugin
+		needs). It floats by default so it resolves a version that satisfies whichever
+		Plugin.AdMob is referenced (source pins one MAUI, the published package requires a
+		newer one); CI can pin it via -p:MauiVersion=<x>.
+	-->
+
+	<PropertyGroup>
+		<TargetFrameworks>net10.0-android;net10.0-ios</TargetFrameworks>
+		<OutputType>Exe</OutputType>
+		<RootNamespace>Plugin.AdMob.DeviceTests</RootNamespace>
+		<UseMaui>true</UseMaui>
+		<SingleProject>true</SingleProject>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<ApplicationTitle>AdMob Device Tests</ApplicationTitle>
+		<ApplicationId>com.plugin.admob.devicetests</ApplicationId>
+		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+		<ApplicationVersion>1</ApplicationVersion>
+
+		<!-- Bounded to major 10: every TFM here is net10.0-*, so an unbounded `*` could float
+		     onto a future major the project cannot build. CI pins both explicitly. -->
+		<AdMobPackageVersion Condition="'$(AdMobPackageVersion)' == ''">10.*</AdMobPackageVersion>
+		<MauiVersion Condition="'$(MauiVersion)' == ''">10.*</MauiVersion>
+	</PropertyGroup>
+
+	<!-- See: https://github.com/marius-bughiu/Plugin.AdMob/issues/68 -->
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
+		<SupportedOSPlatformVersion>23.0</SupportedOSPlatformVersion>
+	</PropertyGroup>
+
+	<!-- Jc.UMP.iOS buildTransitive targets fail unless SupportedOSPlatformVersion is set explicitly -->
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
+		<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
+		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+	</ItemGroup>
+
+	<!-- SOURCE reference (default): validates the code on this branch. -->
+	<ItemGroup Condition="'$(UsePublishedAdMob)' != 'true'">
+		<ProjectReference Include="..\..\src\Plugin.AdMob\Plugin.AdMob.csproj" />
+	</ItemGroup>
+
+	<!-- PUBLISHED reference: validates the shipped NuGet artifact. -->
+	<ItemGroup Condition="'$(UsePublishedAdMob)' == 'true'">
+		<PackageReference Include="Plugin.AdMob" Version="$(AdMobPackageVersion)" />
+	</ItemGroup>
+
+	<Target Name="LinkWithSwift" DependsOnTargets="_ParseBundlerArguments;_DetectSdkLocations" BeforeTargets="_LinkNativeExecutable" Condition="'$(TargetFramework)' == 'net10.0-ios'">
+		<PropertyGroup>
+			<_SwiftPlatform Condition="$(RuntimeIdentifier.StartsWith('iossimulator-'))">iphonesimulator</_SwiftPlatform>
+			<_SwiftPlatform Condition="$(RuntimeIdentifier.StartsWith('ios-'))">iphoneos</_SwiftPlatform>
+		</PropertyGroup>
+		<ItemGroup>
+			<_CustomLinkFlags Include="-L" />
+			<_CustomLinkFlags Include="/usr/lib/swift" />
+			<_CustomLinkFlags Include="-L" />
+			<_CustomLinkFlags Include="$(_SdkDevPath)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(_SwiftPlatform)" />
+			<_CustomLinkFlags Include="-Wl,-rpath" />
+			<_CustomLinkFlags Include="-Wl,/usr/lib/swift" />
+		</ItemGroup>
+	</Target>
+
+</Project>

--- a/tests/Plugin.AdMob.DeviceTests/Resources/AppIcon/appicon.svg
+++ b/tests/Plugin.AdMob.DeviceTests/Resources/AppIcon/appicon.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="456" height="456" viewBox="0 0 456 456" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="456" height="456" fill="#512BD4" />
+</svg>

--- a/tests/Plugin.AdMob.DeviceTests/Resources/AppIcon/appiconfg.svg
+++ b/tests/Plugin.AdMob.DeviceTests/Resources/AppIcon/appiconfg.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="456" height="456" viewBox="0 0 456 456" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="228" cy="228" r="120" fill="#FFFFFF" />
+</svg>

--- a/tests/Plugin.AdMob.DeviceTests/Resources/Splash/splash.svg
+++ b/tests/Plugin.AdMob.DeviceTests/Resources/Splash/splash.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="456" height="456" viewBox="0 0 456 456" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="228" cy="228" r="120" fill="#FFFFFF" />
+</svg>

--- a/tests/Plugin.AdMob.PackageConsumer/ApiSurface.cs
+++ b/tests/Plugin.AdMob.PackageConsumer/ApiSurface.cs
@@ -1,0 +1,48 @@
+using Microsoft.Maui.Hosting;
+using Plugin.AdMob;
+using Plugin.AdMob.Configuration;
+using Plugin.AdMob.Services;
+
+namespace Plugin.AdMob.PackageConsumer;
+
+/// <summary>
+/// Touches the published package's public API on every target framework so the build smoke
+/// fails if a released version drops, renames, or changes the signature of anything a real
+/// consumer depends on. Nothing here runs — it only has to compile and link.
+/// </summary>
+public static class ApiSurface
+{
+    public static MauiAppBuilder Configure(MauiAppBuilder builder)
+    {
+        // The one-line consumer entry point.
+        builder.UseAdMob();
+
+        // Global configuration surface.
+        AdConfig.UseTestAdUnitIds = true;
+        AdConfig.DisableConsentCheck = true;
+        AdConfig.AddTestDevice("test-device");
+
+        return builder;
+    }
+
+    // Reference the public ad types / service contracts so they must exist and keep their shape.
+    public static readonly Type[] PublicSurface =
+    [
+        typeof(BannerAd),
+        typeof(NativeAdView),
+        typeof(MediaView),
+        typeof(IInterstitialAdService),
+        typeof(IRewardedAdService),
+        typeof(IRewardedInterstitialAdService),
+        typeof(IAppOpenAdService),
+        typeof(INativeAdService),
+        typeof(IAdConsentService),
+        typeof(IInterstitialAd),
+        typeof(IRewardedAd),
+        typeof(IRewardedInterstitialAd),
+        typeof(IAppOpenAd),
+        typeof(INativeAd),
+        typeof(IAdError),
+        typeof(VideoOptions),
+    ];
+}

--- a/tests/Plugin.AdMob.PackageConsumer/Plugin.AdMob.PackageConsumer.csproj
+++ b/tests/Plugin.AdMob.PackageConsumer/Plugin.AdMob.PackageConsumer.csproj
@@ -1,0 +1,61 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<!--
+		Restore + build smoke test consumer.
+
+		This is a MAUI class library (not an app) that references the PUBLISHED
+		Plugin.AdMob NuGet package across every target framework the package ships.
+		Its only job is to prove that the shipped .nupkg and its transitive native
+		binding graph (Xamarin.GooglePlayServices.Ads.Lite, Jc.GMA.iOS, Jc.UMP.iOS,
+		Xamarin.AndroidX.*.Ktx, ...) still restore and compile for a consumer.
+
+		It deliberately does NOT ProjectReference src/Plugin.AdMob — testing the
+		published artifact is the whole point.
+
+		Both the plugin version and MAUI float by default so a plain restore pulls the
+		newest published versions; CI pins them for a deterministic run via
+		-p:AdMobPackageVersion=<x> -p:MauiVersion=<y>. MAUI must be referenced explicitly
+		and at a version that satisfies the package's own MAUI requirement (as of .NET 8
+		<UseMaui>true</UseMaui> no longer injects it, and the SDK-bundled floor is older
+		than the plugin needs — a mismatch would surface as an NU1605 downgrade).
+	-->
+
+	<PropertyGroup>
+		<TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
+		<UseMaui>true</UseMaui>
+		<SingleProject>true</SingleProject>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+
+		<!-- Floating by default so a plain restore pulls the newest published versions. CI overrides with explicit versions. -->
+		<!-- Bounded to major 10: every TFM here is net10.0-*, so an unbounded `*` could float
+		     onto a future major the project cannot build. CI pins both explicitly. -->
+		<AdMobPackageVersion Condition="'$(AdMobPackageVersion)' == ''">10.*</AdMobPackageVersion>
+		<MauiVersion Condition="'$(MauiVersion)' == ''">10.*</MauiVersion>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
+		<SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
+		<SupportedOSPlatformVersion>23.0</SupportedOSPlatformVersion>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+		<SupportedOSPlatformVersion>13.1</SupportedOSPlatformVersion>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+		<SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Plugin.AdMob" Version="$(AdMobPackageVersion)" />
+	</ItemGroup>
+
+</Project>

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,80 @@
+# Integration tests & CI gates
+
+Two tiers of automated checks, both aimed at the same failure class: the plugin wraps
+third-party native bindings (`Xamarin.GooglePlayServices.Ads.Lite`, `Jc.GMA.iOS`,
+`Jc.UMP.iOS`, `Xamarin.AndroidX.*.Ktx`) that drift independently of this repo, and the
+plugin version tracks MAUI — so "the world changed under a shipped release" is a real,
+time-driven risk that source-only CI can't catch.
+
+## Projects
+
+| Project | What it is | Used by |
+|---|---|---|
+| [`Plugin.AdMob.PackageConsumer`](Plugin.AdMob.PackageConsumer/) | A MAUI **library** that references the **published** NuGet across all 4 target frameworks. Pure restore + build smoke. | `nightly.yml` |
+| [`Plugin.AdMob.DeviceTests`](Plugin.AdMob.DeviceTests/) | A MAUI **app** that loads every ad format with Google's test units and asserts `OnAdLoaded` fires, logging results under the `AdMobHarness` tag. | `device-tests.yml` |
+
+Both switch between referencing the **source** and the **published package** via MSBuild
+properties, so the same code validates a branch change *and* the shipped artifact:
+
+```bash
+# source (default) — validates the code on this branch
+dotnet build tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj -f net10.0-android
+
+# published package — validates the shipped .nupkg
+dotnet build tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj -f net10.0-android \
+  -p:UsePublishedAdMob=true -p:AdMobPackageVersion=10.0.90 -p:MauiVersion=10.0.90
+```
+
+## Workflows
+
+- **`build.yml`** — source-build gate on every PR / push to `main`. Restores + compiles the
+  plugin and sample app across Android / iOS / MacCatalyst / Windows. Hard-fails on **NU1605**
+  (package downgrade); surfaces **NU1608** (native-binding constraint drift — the issue #68 /
+  #82 class) to the run summary.
+- **`device-tests.yml`** — runs the harness on an Android emulator (gating) and, best-effort,
+  an iOS simulator (advisory). Reusable by the nightly and the bump gate.
+- **`nightly.yml`** — 04:00 UTC. Resolves the latest published version and runs both the build
+  smoke and the device tests **against the published package**.
+- **`bump-maui.yml`** — the MAUI auto-bump now *validates before it publishes*. It pushes the
+  candidate to a throwaway `bump-maui-validate` branch, runs `build.yml` + `device-tests.yml`
+  against that commit, and only then fast-forwards the reviewed `bump-maui-version` branch and
+  opens/updates the PR. So the head of an open bump PR is never replaced by an unvalidated
+  commit, and its body always describes the commit actually on the branch. If someone pushes a
+  manual commit onto `bump-maui-version`, the promotion is skipped rather than clobbering it.
+
+## The banner-vs-full-screen gating model (important)
+
+On a **headless, software-GPU emulator** — which is every GitHub-hosted runner, since they have
+no GPU — only the **banner** format reliably fills. Full-screen (interstitial / rewarded /
+rewarded-interstitial / app-open) and native creatives need a **GPU-backed emulator (`-gpu host`)**
+to pre-render, and otherwise come back as no-fill. This is a documented, hardware-observed quirk,
+not a plugin bug.
+
+So the harness emits two summary lines and CI gates accordingly:
+
+- `SUMMARY_BANNER` → **hard gate** on any runner.
+- `SUMMARY_ALL` → every format; only hard-gated when `require_all_formats: true`.
+
+To get **full-format** coverage, run `device-tests.yml` (or the harness directly) against a
+**`-gpu host` emulator on a self-hosted runner** and pass `require_all_formats: true`. The
+maintainer's local `plugin_admob_ps` (Play Store) AVD is exactly such an environment.
+
+Run the harness locally against a booted `-gpu host` emulator:
+
+```bash
+dotnet build tests/Plugin.AdMob.DeviceTests/Plugin.AdMob.DeviceTests.csproj -c Debug -f net10.0-android \
+  "-p:AndroidSdkDirectory=%LOCALAPPDATA%\Android\Sdk" "-p:JavaSdkDirectory=%LOCALAPPDATA%\Android\Jdk"
+adb install -r tests/Plugin.AdMob.DeviceTests/bin/Debug/net10.0-android/com.plugin.admob.devicetests-Signed.apk
+adb logcat -c && adb shell monkey -p com.plugin.admob.devicetests -c android.intent.category.LAUNCHER 1
+adb logcat -s AdMobHarness:I   # watch RESULT / SUMMARY_* lines
+```
+
+## One manual step: make the gates required
+
+Workflows run automatically, but marking them **required status checks** is a repository
+setting (Settings → Branches → branch protection for `main`): add **`build`** (and, if you want
+it blocking, the device-tests **`android`** job) as required.
+
+Note: PRs opened by `bump-maui.yml` use the default `GITHUB_TOKEN`, which by design does not
+trigger further workflow runs — that is why the bump validates inline before opening the PR. If
+you want the checks to also render on the PR itself, have the bump use a PAT instead.

--- a/tests/ci/run-android-harness.sh
+++ b/tests/ci/run-android-harness.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Installs the pre-built device-test APK on the booted emulator, launches it, and scrapes the
+# harness's result lines from logcat.
+#
+# Banner is the hard gate: it is the one format that reliably fills on a headless, software-GPU
+# emulator (GitHub-hosted runners have no GPU). The full set (SUMMARY_ALL) is only enforced when
+# REQUIRE_ALL=true — i.e. when running against a GPU-backed / -gpu host emulator (e.g. a
+# self-hosted runner) where full-screen and native creatives can actually pre-render and fill.
+
+PKG="com.plugin.admob.devicetests"
+TAG="AdMobHarness"
+REQUIRE_ALL="${REQUIRE_ALL:-false}"
+APK="${APK:?APK env var not set}"
+
+echo "Installing $APK"
+adb install -r "$APK"
+
+adb logcat -c
+echo "Launching $PKG"
+adb shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 >/dev/null
+
+# Wait for the harness to emit its final summary line (or time out).
+deadline=$((SECONDS + 480))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  if adb logcat -d -s "${TAG}:I" | grep -qF "SUMMARY_ALL"; then break; fi
+  sleep 5
+done
+
+echo "===== harness log ====="
+adb logcat -d -s "${TAG}:I" || true
+echo "======================="
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Android device-test results"
+    echo '```'
+    adb logcat -d -s "${TAG}:I" | grep -E "RESULT|SUMMARY" || echo "(no harness output captured)"
+    echo '```'
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+banner=$(adb logcat -d -s "${TAG}:I" | grep -F "SUMMARY_BANNER" | tail -1 || true)
+allline=$(adb logcat -d -s "${TAG}:I" | grep -F "SUMMARY_ALL" | tail -1 || true)
+
+echo "banner:  ${banner:-<none>}"
+echo "all:     ${allline:-<none>}"
+
+if [ -z "$banner" ]; then
+  echo "::error::Harness did not report a banner result (app crashed or never finished loading)."
+  exit 1
+fi
+
+if ! echo "$banner" | grep -q "status=PASS"; then
+  echo "::error::Banner ad failed to load against Google's test ad unit."
+  exit 1
+fi
+
+if [ "$REQUIRE_ALL" = "true" ]; then
+  if ! echo "$allline" | grep -q "status=PASS"; then
+    echo "::error::Not every ad format loaded (require_all_formats=true)."
+    exit 1
+  fi
+fi
+
+echo "Device-test gate passed (banner loaded; require_all_formats=$REQUIRE_ALL)."


### PR DESCRIPTION
## Why

The plugin wraps third-party native bindings — `Xamarin.GooglePlayServices.Ads.Lite`, `Jc.GMA.iOS`, `Jc.UMP.iOS`, `Xamarin.AndroidX.*.Ktx` — that drift independently of this repo, and the package version tracks MAUI. Until now:

- **Nothing built on PR.** The only workflow that ever compiled the code was `release.yml`, and it's `workflow_dispatch`-only.
- **`bump-maui.yml` validated nothing.** It `sed`-edited the version and opened a PR with no restore/build/test. Since `PackageVersion` == `MauiPackageVersion`, that unvalidated bump *is* the next shipped plugin version.
- **Nothing ever exercised the published artifact.** Both sample apps `ProjectReference` the source, so they test the branch, never the shipped `.nupkg` and its transitive binding graph.

Net effect: "the world changed under a shipped release" — the #68 / #82 failure class — was caught only when a user hit it.

## What changed

### Test projects

Both switch between **source** and the **published NuGet** via `-p:UsePublishedAdMob=true`, so the same code validates a branch change *and* the shipped artifact.

- **`tests/Plugin.AdMob.PackageConsumer`** — MAUI library referencing the published package across all 4 TFMs. `ApiSurface.cs` touches the public API so a release that drops or renames anything fails the build.
- **`tests/Plugin.AdMob.DeviceTests`** — MAUI app that loads every ad format against Google's test ad units and asserts `OnAdLoaded` fires, logging `RESULT` / `SUMMARY_*` lines under the `AdMobHarness` tag for CI to scrape.

### Workflows

| Workflow | Trigger | Gate |
|---|---|---|
| `build.yml` (new) | every PR / push to `main` | 4-TFM matrix; hard-fails **NU1605**, surfaces **NU1608** to the summary |
| `device-tests.yml` (new) | reusable | Android emulator (gating) + iOS simulator (advisory) |
| `nightly.yml` (new) | 04:00 UTC | Both tiers against the **latest published** package |
| `bump-maui.yml` (rewritten) | 06:00 UTC | Validates **before** publishing the PR |

`bump-maui` now pushes the candidate to a throwaway `bump-maui-validate` branch, builds and device-tests **that commit**, and only then fast-forwards the reviewed `bump-maui-version` branch and opens/updates the PR. Head, title and body always move together. A manual commit on the review branch skips promotion rather than clobbering it.

## Reviewer notes

**NU1608 reports, it does not fail.** The binding graph emits **8 NU1608 conflicts today** (`Fragment.Ktx`, `Activity.Ktx`, `Collection.Ktx`, `Lifecycle.*`, `SavedState.Ktx`) — the exact issue #82 class. Hard-failing would be red on night one, so NU1605 (downgrade, real breakage) is the hard gate and NU1608 goes to the run summary for eyeballing.

**Banner is the hard gate; full-screen is advisory.** On a headless software-GPU emulator — every GitHub-hosted runner — only banner reliably fills. Full-screen and native creatives need `-gpu host` to pre-render and otherwise return no-fill. So `SUMMARY_BANNER` hard-gates anywhere, and `SUMMARY_ALL` is enforced only with `require_all_formats: true`, intended for a GPU-capable self-hosted runner. (Native demo ads additionally want a Play Store image for `market://` click resolution.)

**Asserting load, not render, is deliberate.** `OnAdLoaded` is a network+SDK callback and is GPU-independent, which is what makes it a stable signal for binding/MAUI drift. This does not verify pixels.

## Verified locally

- DeviceTests (harness + plugin source) and the sample app: **0 errors** with the NU1605 gate
- PackageConsumer against **published 10.0.90**: 0 errors, `10.*` floats resolve correctly
- `run-android-harness.sh` driven against a fake `adb` — all 5 decision paths correct, including **exit 1 when the app crashes** (no false green)
- All 6 workflow YAML files parse

An adversarial review pass raised 11 candidate defects; 7 confirmed and fixed, 4 refuted. Two were blockers: the device-test jobs installed only `maui-android`/`maui-ios` while the harness multi-targets both, which aborts restore with `NETSDK1147` before any APK exists (would have failed *every* night); and the original bump rewrite could replace an open PR's head with unvalidated code while its body still advertised the previous validated version.

## One manual step

Making these **required status checks** is a repo setting (Settings → Branches → branch protection for `main`): add **`build`**, and the device-tests **`android`** job if you want it blocking.

Note: PRs opened by `bump-maui.yml` use the default `GITHUB_TOKEN`, which by design does not trigger further workflow runs — that's why the bump validates inline before opening. Swap in a PAT if you'd rather see the checks render on the PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
